### PR TITLE
Implements entry deduplication in valueStore

### DIFF
--- a/entry/value.go
+++ b/entry/value.go
@@ -56,13 +56,13 @@ func encodeMetadata(protocol uint64, data []byte) []byte {
 // Marshal serializes a Value list for storage
 // TODO: Switch from JSON to a more efficient serialization
 // format once we figure out the right data structure?
-func Marshal(li []Value) ([]byte, error) {
+func Marshal(li Value) ([]byte, error) {
 	return json.Marshal(&li)
 }
 
 // Unmarshal serialized Value list
-func Unmarshal(b []byte) ([]Value, error) {
-	li := []Value{}
+func Unmarshal(b []byte) (Value, error) {
+	li := Value{}
 	err := json.Unmarshal(b, &li)
 	return li, err
 }

--- a/store/entry.go
+++ b/store/entry.go
@@ -1,0 +1,80 @@
+package store
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/filecoin-project/go-indexer-core/entry"
+	"github.com/multiformats/go-multihash"
+	mh "github.com/multiformats/go-multihash"
+)
+
+const (
+	hashAlg  = multihash.SHA2_256
+	hashLen  = 32
+	mhashLen = 32 + 2
+)
+
+// Entry representation for the entry store.
+type Entry struct {
+	Value entry.Value
+	RefC  uint64
+}
+
+// CidEntry represent the list of pointers to entries
+// from the entryStore
+type CidEntry [][]byte
+
+// Marshal StoreEntry for storage and compute the key
+func Marshal(li *Entry) ([]byte, error) {
+	return json.Marshal(li)
+}
+
+// Unmarshal StoreEntry from storage
+func Unmarshal(b []byte) (*Entry, error) {
+	li := &Entry{}
+	err := json.Unmarshal(b, li)
+	return li, err
+}
+
+// JoinKs joins a list of entry keys into the same byte array
+func JoinKs(b [][]byte) []byte {
+	return bytes.Join(b, nil)
+}
+
+// SplitKs splits entry keys from a byte array
+func SplitKs(b []byte) [][]byte {
+	// NOTE: We could consider using bytes.Split here
+	// but this requires adding a separator.
+	// We can save ourselves from using separators as
+	// we know in advance the size multihashes will have.
+	out := [][]byte{}
+	for i := 0; i < len(b); i += mhashLen {
+		t := b[i:(i + mhashLen)]
+		out = append(out, t)
+	}
+	return out
+}
+
+// EntryKey computes the key for an entry pointer
+func EntryKey(in entry.Value) ([]byte, error) {
+	b, err := entry.Marshal(in)
+	if err != nil {
+		return nil, err
+	}
+	h, err := mh.Sum(b, hashAlg, hashLen)
+	if err != nil {
+		return nil, err
+	}
+	return h, nil
+}
+
+// DuplicateEntry checks if the key for the entry is already there.
+func DuplicateEntry(k []byte, old CidEntry) bool {
+	for i := range old {
+		if bytes.Equal(old[i], k) {
+			return true
+		}
+	}
+	return false
+}

--- a/store/entry.go
+++ b/store/entry.go
@@ -5,12 +5,11 @@ import (
 	"encoding/json"
 
 	"github.com/filecoin-project/go-indexer-core/entry"
-	"github.com/multiformats/go-multihash"
 	mh "github.com/multiformats/go-multihash"
 )
 
 const (
-	hashAlg  = multihash.SHA2_256
+	hashAlg  = mh.SHA2_256
 	hashLen  = 32
 	mhashLen = 32 + 2
 )

--- a/store/pogreb/pogreb_bench_test.go
+++ b/store/pogreb/pogreb_bench_test.go
@@ -1,4 +1,4 @@
-package pogreb_test
+package pogreb
 
 import (
 	"runtime"

--- a/store/pogreb/pogreb_test.go
+++ b/store/pogreb/pogreb_test.go
@@ -124,6 +124,7 @@ func TestRefC(t *testing.T) {
 }
 
 func TestParallelRefC(t *testing.T) {
+	skipIf32bit(t)
 	sint, err := initPogreb()
 	if err != nil {
 		t.Fatal(err)

--- a/store/pogreb/pogreb_test.go
+++ b/store/pogreb/pogreb_test.go
@@ -3,6 +3,7 @@ package pogreb
 import (
 	"io/ioutil"
 	"runtime"
+	"sync"
 	"testing"
 
 	"github.com/filecoin-project/go-indexer-core/entry"
@@ -58,14 +59,13 @@ func TestRefC(t *testing.T) {
 		t.Fatal(err)
 	}
 	s := sint.(*pStorage)
-
-	// Create new valid peer.ID
-	p, err := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
+	cids, err := test.RandomCids(15)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	cids, err := test.RandomCids(15)
+	// Create new valid peer.ID
+	p, err := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,8 +118,85 @@ func TestRefC(t *testing.T) {
 		t.Fatal(err)
 	}
 	if found {
-		t.Fatal("Entry should have been removed with RefC==0", ent)
+		t.Error("Entry should have been removed with RefC==0", ent)
 	}
+
+}
+
+func TestParallelRefC(t *testing.T) {
+	sint, err := initPogreb()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cids, err := test.RandomCids(15)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := sint.(*pStorage)
+
+	// Create new valid peer.ID
+	p, err := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entry1 := entry.MakeValue(p, 0, cids[0].Bytes())
+	kEnt1, err := store.EntryKey(entry1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry2 := entry.MakeValue(p, 0, cids[1].Bytes())
+	kEnt2, err := store.EntryKey(entry2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+
+	// Test parallel writes over different CIDs
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(wg *sync.WaitGroup, i int) {
+			t.Logf("Put/Get different cid")
+			_, err := s.Put(cids[i], entry1)
+			if err != nil {
+				t.Error("Error putting single cid: ", err)
+			}
+			wg.Done()
+		}(&wg, i)
+	}
+	wg.Wait()
+	checkRefC(t, s, kEnt1, 5)
+
+	// Test parallel writes over different CIDs
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(wg *sync.WaitGroup) {
+			t.Logf("Put/Get same cid")
+			_, err := s.Put(cids[10], entry2)
+			if err != nil {
+				t.Error("Error putting single cid: ", err)
+			}
+			wg.Done()
+		}(&wg)
+	}
+	wg.Wait()
+	checkRefC(t, s, kEnt2, 1)
+
+	// Test remove for all except one
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func(wg *sync.WaitGroup, i int) {
+			t.Logf("Remove cid")
+			_, err := s.Remove(cids[i], entry1)
+			if err != nil {
+				t.Error("Error removing single cid: ", err)
+			}
+			wg.Done()
+		}(&wg, i)
+	}
+	wg.Wait()
+	checkRefC(t, s, kEnt1, 1)
 }
 
 func checkRefC(t *testing.T, s *pStorage, k []byte, refC uint64) {
@@ -131,7 +208,7 @@ func checkRefC(t *testing.T, s *pStorage, k []byte, refC uint64) {
 		t.Errorf("Error finding single cid")
 	}
 	if ent.RefC != refC {
-		t.Fatal("RefCount should have not changed:", ent.RefC)
+		t.Error("RefCount is not correct:", ent.RefC)
 	}
 }
 

--- a/store/pogreb/pogreb_test.go
+++ b/store/pogreb/pogreb_test.go
@@ -1,12 +1,14 @@
-package pogreb_test
+package pogreb
 
 import (
 	"io/ioutil"
 	"runtime"
 	"testing"
 
+	"github.com/filecoin-project/go-indexer-core/entry"
 	"github.com/filecoin-project/go-indexer-core/store"
-	"github.com/filecoin-project/go-indexer-core/store/pogreb"
+	peer "github.com/libp2p/go-libp2p-core/peer"
+
 	"github.com/filecoin-project/go-indexer-core/store/test"
 )
 
@@ -15,7 +17,7 @@ func initPogreb() (store.Interface, error) {
 	if err != nil {
 		return nil, err
 	}
-	return pogreb.New(tmpDir)
+	return New(tmpDir)
 }
 
 func TestE2E(t *testing.T) {
@@ -46,6 +48,91 @@ func TestRemoveMany(t *testing.T) {
 		t.Fatal(err)
 	}
 	test.RemoveManyTest(t, s)
+}
+
+func TestRefC(t *testing.T) {
+	skipIf32bit(t)
+
+	sint, err := initPogreb()
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := sint.(*pStorage)
+
+	// Create new valid peer.ID
+	p, err := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cids, err := test.RandomCids(15)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entry1 := entry.MakeValue(p, 0, cids[0].Bytes())
+	kEnt1, err := store.EntryKey(entry1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	first := cids[2]
+	second := cids[3]
+
+	// Put a single CID
+	t.Logf("Put/Get first ref")
+	_, err = s.Put(first, entry1)
+	if err != nil {
+		t.Fatal("Error putting single cid: ", err)
+	}
+	checkRefC(t, s, kEnt1, 1)
+
+	t.Logf("Put/Get second ref")
+	_, err = s.Put(second, entry1)
+	if err != nil {
+		t.Fatal("Error putting single cid: ", err)
+	}
+	checkRefC(t, s, kEnt1, 2)
+
+	t.Logf("Put/Get same value again")
+	_, err = s.Put(second, entry1)
+	if err != nil {
+		t.Fatal("Error putting single cid: ", err)
+	}
+	checkRefC(t, s, kEnt1, 2)
+
+	t.Logf("Remove second")
+	_, err = s.Remove(second, entry1)
+	if err != nil {
+		t.Fatal("Error putting single cid: ", err)
+	}
+	checkRefC(t, s, kEnt1, 1)
+
+	t.Logf("Remove first")
+	_, err = s.Remove(first, entry1)
+	if err != nil {
+		t.Fatal("Error putting single cid: ", err)
+	}
+	ent, found, err := s.getEntry(kEnt1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if found {
+		t.Fatal("Entry should have been removed with RefC==0", ent)
+	}
+}
+
+func checkRefC(t *testing.T, s *pStorage, k []byte, refC uint64) {
+	ent, found, err := s.getEntry(k)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Errorf("Error finding single cid")
+	}
+	if ent.RefC != refC {
+		t.Fatal("RefCount should have not changed:", ent.RefC)
+	}
 }
 
 func skipIf32bit(t *testing.T) {

--- a/store/storethehash/storethehash.go
+++ b/store/storethehash/storethehash.go
@@ -1,6 +1,8 @@
 package storethehash
 
 import (
+	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"time"
@@ -22,8 +24,9 @@ const DefaultBurstRate = 4 * 1024 * 1024
 const DefaultSyncInterval = time.Second
 
 type sthStorage struct {
-	dir   string
-	store *sth.Store
+	dir      string
+	store    *sth.Store
+	entStore *sth.Store
 }
 
 func New(dir string) (*sthStorage, error) {
@@ -43,16 +46,64 @@ func New(dir string) (*sthStorage, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Initialize entry storage
+	indexPath = filepath.Join(dir, "sthEntries.index")
+	dataPath = filepath.Join(dir, "sthEntries.data")
+	esPrimary, err := cidprimary.OpenCIDPrimary(dataPath)
+	if err != nil {
+		return nil, err
+	}
+
+	es, err := sth.OpenStore(indexPath, esPrimary, DefaultIndexSizeBits, DefaultSyncInterval, DefaultBurstRate)
+	if err != nil {
+		return nil, err
+	}
+
+	// Start both storages
 	s.Start()
-	return &sthStorage{dir: dir, store: s}, nil
+	es.Start()
+	return &sthStorage{dir: dir, store: s, entStore: es}, nil
 }
 
 func (s *sthStorage) Get(c cid.Cid) ([]entry.Value, bool, error) {
-	return s.get(c.Bytes())
+	out := []entry.Value{}
+	ks, found, err := s.get(c.Bytes())
+	if err != nil {
+		return nil, false, err
+	}
+	if !found {
+		return nil, found, nil
+	}
+	// If keys found, get entries from entryStore
+	for i := range ks {
+		e, found, err := s.getEntry(ks[i])
+		if err != nil {
+			return nil, false, err
+		}
+		if !found {
+			return nil, false, errors.New("one of the entries couldn't be found in entryStore")
+		}
+		out = append(out, e.Value)
+	}
+
+	return out, true, nil
 }
 
-func (s *sthStorage) get(k []byte) ([]entry.Value, bool, error) {
+func (s *sthStorage) get(k []byte) (store.CidEntry, bool, error) {
 	value, found, err := s.store.Get(k)
+	if err != nil {
+		return nil, false, err
+	}
+	if !found {
+		return [][]byte{}, false, nil
+	}
+
+	return store.SplitKs(value), true, nil
+}
+
+func (s *sthStorage) getEntry(k []byte) (*store.Entry, bool, error) {
+	value, found, err := s.entStore.Get(k)
 	if err != nil {
 		return nil, false, err
 	}
@@ -60,12 +111,11 @@ func (s *sthStorage) get(k []byte) ([]entry.Value, bool, error) {
 		return nil, false, nil
 	}
 
-	out, err := entry.Unmarshal(value)
+	out, err := store.Unmarshal(value)
 	if err != nil {
 		return nil, false, err
 	}
 	return out, true, nil
-
 }
 
 func (s *sthStorage) Put(c cid.Cid, entry entry.Value) (bool, error) {
@@ -73,28 +123,64 @@ func (s *sthStorage) Put(c cid.Cid, entry entry.Value) (bool, error) {
 }
 
 func (s *sthStorage) put(k []byte, in entry.Value) (bool, error) {
-	// NOTE: The implementation of Put in storethehash already
-	// performs a first lookup to check the type of update that
-	// needs to be done over the key. We can probably save this
-	// additional get access by implementing the duplicateEntry comparison
-	// low-level
+	entK, err := store.EntryKey(in)
+	if err != nil {
+		return false, err
+	}
 	old, found, err := s.get(k)
 	if err != nil {
 		return false, err
 	}
 	// If found it means there is already a value there.
 	// Check if we are trying to put a duplicate entry
-	if found && duplicateEntry(in, old) {
+	if found && store.DuplicateEntry(entK, old) {
 		return false, nil
 	}
 
-	li := append(old, in)
-	b, err := entry.Marshal(li)
+	// If no duplicate put the entry.
+	ok, err := s.putEntry(entK, in)
 	if err != nil {
 		return false, err
 	}
+	// Ok needs to be true, RefC needs to be increased successfully
+	if !ok {
+		return false, errors.New("failed to put entry in entryStore")
+	}
+	li := append(old, entK)
 
-	err = s.store.Put(k, b)
+	err = s.store.Put(k, store.JoinKs(li))
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (s *sthStorage) putEntry(k []byte, in entry.Value) (bool, error) {
+	old, found, err := s.getEntry(k)
+	if err != nil {
+		return false, err
+	}
+	// Found in store. Increase RefC and update in store
+	if found {
+		old.RefC++
+		b, err := store.Marshal(old)
+		if err != nil {
+			return false, err
+		}
+		s.entStore.Put(k, b)
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+
+	// If not found the entry is new and needs to be fully put.
+	e := &store.Entry{Value: in, RefC: 1}
+	b, err := store.Marshal(e)
+	if err != nil {
+		return false, err
+	}
+	err = s.entStore.Put(k, b)
 	if err != nil {
 		return false, err
 	}
@@ -114,32 +200,35 @@ func (s *sthStorage) PutMany(cs []cid.Cid, entry entry.Value) error {
 }
 
 func (s *sthStorage) Flush() error {
+	// Flush entry store
+	s.entStore.Flush()
+	if err := s.entStore.Err(); err != nil {
+		return err
+	}
+	// Flush store
 	s.store.Flush()
 	return s.store.Err()
 }
 
+func (s *sthStorage) Close() error {
+	return s.store.Close()
+}
+
 func (s *sthStorage) Size() (int64, error) {
-	// NOTE: Should we flush to commit all changes before returning the
-	// size?
-	size := int64(0)
-	fi, err := os.Stat(filepath.Join(s.dir, "storethehash.data"))
-	if err != nil {
-		return size, err
-	}
-	size += fi.Size()
-	fi, err = os.Stat(filepath.Join(s.dir, "storethehash.index"))
-	if err != nil {
-		return size, err
-	}
-	size += fi.Size()
-	fi, err = os.Stat(filepath.Join(s.dir, "storethehash.index.free"))
-	if err != nil {
-		return size, err
-	}
-	size += fi.Size()
-	return size, nil
+	var size int64
+	err := filepath.Walk(s.dir, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			size += info.Size()
+		}
+		return err
+	})
+	return size, err
 
 }
+
 func (s *sthStorage) Remove(c cid.Cid, entry entry.Value) (bool, error) {
 	return s.remove(c, entry)
 }
@@ -172,51 +261,66 @@ func (s *sthStorage) RemoveMany(cids []cid.Cid, entry entry.Value) error {
 // when a provider is no longer indexed by the indexer.
 func (s *sthStorage) RemoveProvider(providerID peer.ID) error {
 	// NOTE: There is no straightforward way of implementing this
-	// batch remove. We can either regenerate the index from
-	// the original data, or iterate through the whole the whole primary storage
-	// inspecting all entries for the provider in cids.
+	// batch remove. We could use an offline process which
+	// iterates through all keys removing/updating
+	// the ones belonging to provider.
 	// Deferring to the future
 	panic("not implemented")
 }
 
-// DuplicateEntry checks if the entry already exists in the index. An entry
-// for the same provider but different metadata is not considered
-// a duplicate entry.
-func duplicateEntry(in entry.Value, old []entry.Value) bool {
-	for i := range old {
-		if in.Equal(old[i]) {
-			return true
-		}
+func (s *sthStorage) decreaseRefC(k []byte) (bool, error) {
+	old, found, err := s.getEntry(k)
+	if err != nil {
+		return false, err
 	}
-	return false
+	if !found {
+		return false, errors.New("cannot decrease RefC from non-existing entry")
+	}
+
+	// Decrease RefC
+	old.RefC--
+	// If RefC == 0 remove the full entry
+	if old.RefC == 0 {
+		return s.entStore.Remove(k)
+	}
+	// If not we put entry with the updated refCount
+	b, err := store.Marshal(old)
+	if err != nil {
+		return false, err
+	}
+	s.entStore.Put(k, b)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
-func (s *sthStorage) removeEntry(k []byte, value entry.Value, stored []entry.Value) (bool, error) {
+func (s *sthStorage) removeEntry(k []byte, value entry.Value, stored store.CidEntry) (bool, error) {
+	entK, err := store.EntryKey(value)
+	if err != nil {
+		return false, err
+	}
 	for i := range stored {
-		if value.Equal(stored[i]) {
+		if bytes.Equal(entK, stored[i]) {
 			// It is the only value, remove the value
 			if len(stored) == 1 {
-				return s.store.Remove(k)
+				_, err := s.store.Remove(k)
+				if err != nil {
+					return false, err
+				}
+			} else {
+				// else remove the key and put updated structure
+				stored[i] = stored[len(stored)-1]
+				stored[len(stored)-1] = []byte{}
+				b := store.JoinKs(stored[:len(stored)-1])
+				if err := s.store.Put(k, b); err != nil {
+					return false, err
+				}
 			}
 
-			// else remove from value and put updated structure
-			stored[i] = stored[len(stored)-1]
-			stored[len(stored)-1] = entry.Value{}
-			b, err := entry.Marshal(stored[:len(stored)-1])
-			if err != nil {
-				return false, err
-			}
-			if err := s.store.Put(k, b); err != nil {
-				return false, err
-			}
-			return true, nil
+			// With the key removed, decrease RefCount from entry
+			return s.decreaseRefC(entK)
 		}
 	}
 	return false, nil
-}
-
-// Close stops all storage-related routines, and flushes
-// pending data
-func (s *sthStorage) Close() error {
-	return s.store.Close()
 }

--- a/store/storethehash/storethehash_bench_test.go
+++ b/store/storethehash/storethehash_bench_test.go
@@ -1,4 +1,4 @@
-package storethehash_test
+package storethehash
 
 import (
 	"testing"

--- a/store/storethehash/storethehash_test.go
+++ b/store/storethehash/storethehash_test.go
@@ -179,6 +179,9 @@ func TestRefC(t *testing.T) {
 }
 
 func TestParallelRefC(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.SkipNow()
+	}
 	sint, err := initSth()
 	if err != nil {
 		t.Fatal(err)

--- a/store/storethehash/storethehash_test.go
+++ b/store/storethehash/storethehash_test.go
@@ -3,6 +3,7 @@ package storethehash
 import (
 	"io/ioutil"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -177,6 +178,81 @@ func TestRefC(t *testing.T) {
 	}
 }
 
+func TestParallelRefC(t *testing.T) {
+	sint, err := initSth()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cids, err := test.RandomCids(15)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := sint.(*sthStorage)
+
+	// Create new valid peer.ID
+	p, err := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entry1 := entry.MakeValue(p, 0, cids[0].Bytes())
+	kEnt1, err := store.EntryKey(entry1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry2 := entry.MakeValue(p, 0, cids[1].Bytes())
+	kEnt2, err := store.EntryKey(entry2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+
+	// Test parallel writes over different CIDs
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(wg *sync.WaitGroup, i int) {
+			t.Logf("Put/Get different cid")
+			_, err := s.Put(cids[i], entry1)
+			if err != nil {
+				t.Error("Error putting single cid: ", err)
+			}
+			wg.Done()
+		}(&wg, i)
+	}
+	wg.Wait()
+	checkRefC(t, s, kEnt1, 5)
+
+	// Test parallel writes over different CIDs
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(wg *sync.WaitGroup) {
+			t.Logf("Put/Get same cid")
+			_, err := s.Put(cids[10], entry2)
+			if err != nil {
+				t.Error("Error putting single cid: ", err)
+			}
+			wg.Done()
+		}(&wg)
+	}
+	wg.Wait()
+	checkRefC(t, s, kEnt2, 1)
+
+	// Test remove for all except one
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func(wg *sync.WaitGroup, i int) {
+			t.Logf("Remove cid")
+			_, err := s.Remove(cids[i], entry1)
+			if err != nil {
+				t.Error("Error removing single cid: ", err)
+			}
+			wg.Done()
+		}(&wg, i)
+	}
+	wg.Wait()
+	checkRefC(t, s, kEnt1, 1)
+}
 func checkRefC(t *testing.T, s *sthStorage, k []byte, refC uint64) {
 	ent, found, err := s.getEntry(k)
 	if err != nil {

--- a/store/storethehash/storethehash_test.go
+++ b/store/storethehash/storethehash_test.go
@@ -64,7 +64,7 @@ func TestPeriodicFlush(t *testing.T) {
 	}
 
 	// Put some data in the first storage.
-	cids, err := test.RandomCids(151)
+	cids, err := test.RandomCids(15)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,6 +101,13 @@ func TestPeriodicFlush(t *testing.T) {
 }
 
 func TestRefC(t *testing.T) {
+	// NOTE: This test is flaky in Windows. CI fails with
+	// runtime: out of memory: cannot allocate 134217728-byte block (1417543680 in use)
+	// fatal error: out of memory
+	// Skipping it for now, but we should revisit this.
+	if runtime.GOOS == "windows" {
+		t.SkipNow()
+	}
 	sint, err := initSth()
 	if err != nil {
 		t.Fatal(err)
@@ -180,11 +187,5 @@ func checkRefC(t *testing.T, s *sthStorage, k []byte, refC uint64) {
 	}
 	if ent.RefC != refC {
 		t.Fatal("RefCount should have not changed:", ent.RefC)
-	}
-}
-
-func skipIf32bit(t *testing.T) {
-	if runtime.GOARCH == "386" {
-		t.Skip("Pogreb cannot use GOARCH=386")
 	}
 }

--- a/store/wrapped.go
+++ b/store/wrapped.go
@@ -15,23 +15,19 @@ const (
 )
 
 // Entry representation for the entry store.
-type Entry struct {
+type WrappedValue struct {
 	Value entry.Value
 	RefC  uint64
 }
 
-// CidEntry represent the list of pointers to entries
-// from the entryStore
-type CidEntry [][]byte
-
 // Marshal StoreEntry for storage and compute the key
-func Marshal(li *Entry) ([]byte, error) {
+func Marshal(li *WrappedValue) ([]byte, error) {
 	return json.Marshal(li)
 }
 
 // Unmarshal StoreEntry from storage
-func Unmarshal(b []byte) (*Entry, error) {
-	li := &Entry{}
+func Unmarshal(b []byte) (*WrappedValue, error) {
+	li := &WrappedValue{}
 	err := json.Unmarshal(b, li)
 	return li, err
 }
@@ -69,7 +65,7 @@ func EntryKey(in entry.Value) ([]byte, error) {
 }
 
 // DuplicateEntry checks if the key for the entry is already there.
-func DuplicateEntry(k []byte, old CidEntry) bool {
+func DuplicateEntry(k []byte, old [][]byte) bool {
 	for i := range old {
 		if bytes.Equal(old[i], k) {
 			return true


### PR DESCRIPTION
Implements entry deduplication into `pogreb` and `storethehash`-backed valueStores by combining two stores:
- One that maps CID -> hash(entryKey)
- One that maps hash(entryKey) -> entry value.

The scheme penalizes the performance of get operation in exchange for a more efficient use of storage. After some initial benchmarks, this improvement seems to be penalizing more `storethehash` than `pogreb`, making now `pogreb` ~20% faster on get operations than `storethehash`.

We can probably improve the difference by implementing value de-duplication low-level in storethehash as described here: https://github.com/filecoin-project/storetheindex/issues/18

Leaving the PR as draft for now until we perform more benchmarks and make a decision.