### PR TITLE
Move ReadCids into entry package

### DIFF
--- a/entry/cidreader.go
+++ b/entry/cidreader.go
@@ -1,0 +1,43 @@
+package entry
+
+import (
+	"bufio"
+	"context"
+	"io"
+
+	"github.com/ipfs/go-cid"
+)
+
+// ReadCids reads cids from an io.Reader and outputs them on a channel.
+// Malformed cids are ignored.  ReadCids is meant to be called in a separate
+// goroutine. It exits when EOF on in io.Reader or when context caceled.
+func ReadCids(ctx context.Context, in io.Reader, out chan cid.Cid, done chan error) {
+	defer close(out)
+	defer close(done)
+
+	r := bufio.NewReader(in)
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			if err != io.EOF {
+				done <- err
+			}
+			return
+		}
+		c, err := cid.Decode(line)
+		if err != nil {
+			// Ignore malformed CIDs
+			continue
+		}
+		if ctx != nil {
+			select {
+			case out <- c:
+			case <-ctx.Done():
+				done <- ctx.Err()
+				return
+			}
+		} else {
+			out <- c
+		}
+	}
+}

--- a/entry/cidreader.go
+++ b/entry/cidreader.go
@@ -29,15 +29,11 @@ func ReadCids(ctx context.Context, in io.Reader, out chan cid.Cid, done chan err
 			// Ignore malformed CIDs
 			continue
 		}
-		if ctx != nil {
-			select {
-			case out <- c:
-			case <-ctx.Done():
-				done <- ctx.Err()
-				return
-			}
-		} else {
-			out <- c
+		select {
+		case out <- c:
+		case <-ctx.Done():
+			done <- ctx.Err()
+			return
 		}
 	}
 }

--- a/store/test/benchmarks.go
+++ b/store/test/benchmarks.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"os"
@@ -39,7 +40,7 @@ func prepare(s store.Interface, size string, t *testing.T) {
 
 	out := make(chan cid.Cid)
 	errOut := make(chan error, 1)
-	go entry.ReadCids(nil, file, out, errOut)
+	go entry.ReadCids(context.Background(), file, out, errOut)
 
 	for c := range out {
 		entry := entry.MakeValue(p, protocolID, c.Bytes())
@@ -67,7 +68,7 @@ func readAll(s store.Interface, size string, m *metrics, t *testing.T) {
 	}
 	defer file.Close()
 
-	go entry.ReadCids(nil, file, out, errOut)
+	go entry.ReadCids(context.Background(), file, out, errOut)
 
 	for c := range out {
 		now := time.Now()

--- a/store/test/cidgen.go
+++ b/store/test/cidgen.go
@@ -1,8 +1,6 @@
 package test
 
 import (
-	"bufio"
-	"io"
 	"math/rand"
 	"time"
 
@@ -32,30 +30,4 @@ func RandomCids(n int) ([]cid.Cid, error) {
 		res[i] = c
 	}
 	return res, nil
-}
-
-// ReadCids reads cids from an io.Reader and outputs them on a channel.
-// Malformed cids are ignored.
-func ReadCids(in io.Reader, out chan cid.Cid, done chan error) {
-	defer close(out)
-	defer close(done)
-
-	r := bufio.NewReader(in)
-	var line []byte
-	var err error
-	for {
-		line, err = r.ReadBytes('\n')
-		if err != nil {
-			if err != io.EOF {
-				done <- err
-			}
-			return
-		}
-		c, err := cid.Decode(string(line))
-		if err != nil {
-			// Disregarding malformed CIDs for now
-			continue
-		}
-		out <- c
-	}
 }


### PR DESCRIPTION
- Make `ReadCids` available to clients of this library
- If test data files are not found, then skip test