### PR TITLE
Fix data race in valueStore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/adlrocha/mapmutex v0.0.0-20200716162114-c133e97096b7
 	github.com/akrylysov/pogreb v0.10.1
 	github.com/gammazero/radixtree v0.2.3
+	github.com/im7mortal/kmutex v1.0.1
 	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-log/v2 v2.2.0
 	github.com/ipld/go-storethehash v0.0.0-20210713070316-1ea50cc878b8

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/filecoin-project/go-indexer-core
 go 1.15
 
 require (
+	github.com/adlrocha/mapmutex v0.0.0-20200716162114-c133e97096b7
 	github.com/akrylysov/pogreb v0.10.1
 	github.com/gammazero/radixtree v0.2.3
 	github.com/ipfs/go-cid v0.0.7

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/filecoin-project/go-indexer-core
 go 1.15
 
 require (
-	github.com/adlrocha/mapmutex v0.0.0-20200716162114-c133e97096b7
 	github.com/akrylysov/pogreb v0.10.1
 	github.com/gammazero/radixtree v0.2.3
 	github.com/im7mortal/kmutex v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETFUpAzWW2ep1Y=
 github.com/Stebalien/go-bitfield v0.0.1/go.mod h1:GNjFpasyUVkHMsfEOk8EFLJ9syQ6SI+XWrX9Wf2XH0s=
+github.com/adlrocha/mapmutex v0.0.0-20200716162114-c133e97096b7 h1:3KRTRJj+8mxwDraDn/JbVn+5eq4xKyOYPRoPT4AX3bg=
+github.com/adlrocha/mapmutex v0.0.0-20200716162114-c133e97096b7/go.mod h1:596FG/m9tozAXpew5VPcfXH4vW2RvB1WJohvlC7bqUo=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/akrylysov/pogreb v0.10.1 h1:FqlR8VR7uCbJdfUob916tPM+idpKgeESDXOA1K0DK4w=
 github.com/akrylysov/pogreb v0.10.1/go.mod h1:pNs6QmpQ1UlTJKDezuRWmaqkgUE2TuU0YTWyqJZ7+lI=

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uG
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huin/goupnp v1.0.0/go.mod h1:n9v9KO1tAxYH82qOn+UTIFQDmx5n1Zxd/ClZDMX7Bnc=
 github.com/huin/goutil v0.0.0-20170803182201-1ca381bf3150/go.mod h1:PpLOETDnJ0o3iZrZfqZzyLl6l7F3c6L1oWn7OICBi6o=
+github.com/im7mortal/kmutex v1.0.1 h1:zAACzjwD+OEknDqnLdvRa/BhzFM872EBwKijviGLc9Q=
+github.com/im7mortal/kmutex v1.0.1/go.mod h1:f71c/Ugk/+58OHRAgvgzPP3QEiWGUjK13fd8ozfKWdo=
 github.com/ipfs/bbloom v0.0.1/go.mod h1:oqo8CVWsJFMOZqTglBG4wydCE4IQA/G2/SEofB0rjUI=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
 github.com/ipfs/go-bitswap v0.1.0/go.mod h1:FFJEf18E9izuCqUtHxbWEvq+reg7o4CW5wSAE1wsxj0=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETFUpAzWW2ep1Y=
 github.com/Stebalien/go-bitfield v0.0.1/go.mod h1:GNjFpasyUVkHMsfEOk8EFLJ9syQ6SI+XWrX9Wf2XH0s=
-github.com/adlrocha/mapmutex v0.0.0-20200716162114-c133e97096b7 h1:3KRTRJj+8mxwDraDn/JbVn+5eq4xKyOYPRoPT4AX3bg=
-github.com/adlrocha/mapmutex v0.0.0-20200716162114-c133e97096b7/go.mod h1:596FG/m9tozAXpew5VPcfXH4vW2RvB1WJohvlC7bqUo=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/akrylysov/pogreb v0.10.1 h1:FqlR8VR7uCbJdfUob916tPM+idpKgeESDXOA1K0DK4w=
 github.com/akrylysov/pogreb v0.10.1/go.mod h1:pNs6QmpQ1UlTJKDezuRWmaqkgUE2TuU0YTWyqJZ7+lI=

--- a/store/pogreb/pogreb_test.go
+++ b/store/pogreb/pogreb_test.go
@@ -28,6 +28,16 @@ func TestE2E(t *testing.T) {
 	test.E2ETest(t, s)
 }
 
+func TestParallel(t *testing.T) {
+	skipIf32bit(t)
+
+	s, err := initPogreb()
+	if err != nil {
+		t.Fatal(err)
+	}
+	test.ParallelUpdateTest(t, s)
+}
+
 func TestSize(t *testing.T) {
 	skipIf32bit(t)
 

--- a/store/storethehash/storethehash.go
+++ b/store/storethehash/storethehash.go
@@ -1,6 +1,7 @@
 package storethehash
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"github.com/filecoin-project/go-indexer-core/store"
 	cidprimary "github.com/ipld/go-storethehash/store/primary/cid"
 
+	mapmutex "github.com/adlrocha/mapmutex"
 	"github.com/ipfs/go-cid"
 	sth "github.com/ipld/go-storethehash/store"
 	peer "github.com/libp2p/go-libp2p-core/peer"
@@ -24,6 +26,7 @@ const DefaultSyncInterval = time.Second
 type sthStorage struct {
 	dir   string
 	store *sth.Store
+	mlk   *mapmutex.Mutex
 }
 
 func New(dir string) (*sthStorage, error) {
@@ -44,7 +47,11 @@ func New(dir string) (*sthStorage, error) {
 		return nil, err
 	}
 	s.Start()
-	return &sthStorage{dir: dir, store: s}, nil
+	return &sthStorage{
+		dir:   dir,
+		store: s,
+		mlk:   mapmutex.NewMapMutex(),
+	}, nil
 }
 
 func (s *sthStorage) Get(c cid.Cid) ([]entry.Value, bool, error) {
@@ -73,6 +80,12 @@ func (s *sthStorage) Put(c cid.Cid, entry entry.Value) (bool, error) {
 }
 
 func (s *sthStorage) put(k []byte, in entry.Value) (bool, error) {
+	// Acquire lock
+	err := s.lock(k)
+	if err != nil {
+		return false, err
+	}
+	defer s.unlock(k)
 	// NOTE: The implementation of Put in storethehash already
 	// performs a first lookup to check the type of update that
 	// needs to be done over the key. We can probably save this
@@ -146,6 +159,13 @@ func (s *sthStorage) Remove(c cid.Cid, entry entry.Value) (bool, error) {
 
 func (s *sthStorage) remove(c cid.Cid, entry entry.Value) (bool, error) {
 	k := c.Bytes()
+	// Acquire lock
+	err := s.lock(k)
+	if err != nil {
+		return false, err
+	}
+	defer s.unlock(k)
+
 	old, found, err := s.get(k)
 	if err != nil {
 		return false, err
@@ -219,4 +239,15 @@ func (s *sthStorage) removeEntry(k []byte, value entry.Value, stored []entry.Val
 // pending data
 func (s *sthStorage) Close() error {
 	return s.store.Close()
+}
+
+func (s *sthStorage) lock(k []byte) error {
+	if !s.mlk.TryLock(string(k)) {
+		return errors.New("couldn't get the lock after maxRetries")
+	}
+	return nil
+}
+
+func (s *sthStorage) unlock(k []byte) {
+	s.mlk.Unlock(string(k))
 }

--- a/store/storethehash/storethehash_test.go
+++ b/store/storethehash/storethehash_test.go
@@ -45,6 +45,14 @@ func TestRemoveMany(t *testing.T) {
 	test.RemoveManyTest(t, s)
 }
 
+func TestParallel(t *testing.T) {
+	s, err := initSth()
+	if err != nil {
+		t.Fatal(err)
+	}
+	test.ParallelUpdateTest(t, s)
+}
+
 func TestPeriodicFlush(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.SkipNow()


### PR DESCRIPTION
There was a data race not detectable with `-race` (as it involved the underlying persistence) when updating the same CID with different entries in parallel. This PR fixes the bug and adds a Test to catch it in the future.

To avoid having a single lock for the whole storage, I chose to implement a mapmutex to increase the lock granularity. I realized half-way that someone else had already implemented exactly what I was trying to do, and decided to fork their code so we can maintain it (if needed) without friction. See https://github.com/adlrocha/mapmutex