### PR TITLE
Define an interface for the indexer

### DIFF
--- a/cache/interface.go
+++ b/cache/interface.go
@@ -1,7 +1,7 @@
 package cache
 
 import (
-	"github.com/filecoin-project/go-indexer-core/entry"
+	"github.com/filecoin-project/go-indexer-core"
 	"github.com/ipfs/go-cid"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 )
@@ -10,16 +10,16 @@ import (
 // cache only keeps results for completed requests, and may only store a
 // limited quantity of values.
 type Interface interface {
-	// Get retrieves a slice of IndexEntry for a CID
-	Get(cid.Cid) ([]entry.Value, bool, error)
-	// Put stores an additional IndexEntry for a CID if the entry is not already stored
-	Put(cid.Cid, entry.Value) (bool, error)
-	// PutMany stores an IndexEntry for multiple CIDs
-	PutMany([]cid.Cid, entry.Value) error
-	// Remove removes an IndexEntry for a CID
-	Remove(cid.Cid, entry.Value) (bool, error)
-	// RemoveMany removes an IndexEntry from multiple CIDs
-	RemoveMany([]cid.Cid, entry.Value) error
+	// Get retrieves a slice of indexer.Value for a CID
+	Get(cid.Cid) ([]indexer.Value, bool, error)
+	// Put stores an additional indexer.Value for a CID if the value is not already stored
+	Put(cid.Cid, indexer.Value) (bool, error)
+	// PutMany stores an indexer.Value for multiple CIDs
+	PutMany([]cid.Cid, indexer.Value) error
+	// Remove removes an indexer.Value for a CID
+	Remove(cid.Cid, indexer.Value) (bool, error)
+	// RemoveMany removes an indexer.Value from multiple CIDs
+	RemoveMany([]cid.Cid, indexer.Value) error
 	// RemoveProvider removes all entries for specified provider.  This is used
 	// when a provider is no longer indexed by the indexer.
 	RemoveProvider(peer.ID) error

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -3,7 +3,6 @@ package engine
 import (
 	"github.com/filecoin-project/go-indexer-core"
 	"github.com/filecoin-project/go-indexer-core/cache"
-	"github.com/filecoin-project/go-indexer-core/entry"
 	"github.com/filecoin-project/go-indexer-core/store"
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
@@ -33,8 +32,8 @@ func New(resultCache cache.Interface, valueStore store.Interface) *Engine {
 	}
 }
 
-// Get retrieves a slice of entry.Value for a CID
-func (e *Engine) Get(c cid.Cid) ([]entry.Value, bool, error) {
+// Get retrieves a slice of index.Value for a CID
+func (e *Engine) Get(c cid.Cid) ([]indexer.Value, bool, error) {
 	if e.resultCache != nil {
 		// Check if CID in resultCache
 		v, found, err := e.resultCache.Get(c)
@@ -48,8 +47,8 @@ func (e *Engine) Get(c cid.Cid) ([]entry.Value, bool, error) {
 				return nil, false, err
 			}
 			// TODO: What about adding a resultCache interface that includes
-			// putEntries(cid, []entry.Value) function
-			// so we don't need to loop through entry.Value slice to move from
+			// putValues(cid, []indexer.Value) function
+			// so we don't need to loop through indexer.Value slice to move from
 			// one storage to another?
 			if found {
 				// Move from value store to result cache
@@ -72,7 +71,7 @@ func (e *Engine) Get(c cid.Cid) ([]entry.Value, bool, error) {
 
 // Put stores a value for a CID if the value is not already stored.  New values
 // are added to those that are already stored for the CID.
-func (e *Engine) Put(c cid.Cid, value entry.Value) (bool, error) {
+func (e *Engine) Put(c cid.Cid, value indexer.Value) (bool, error) {
 	// If there is a result cache, check first if cid already in cache
 	if e.resultCache != nil {
 		v, found, err := e.resultCache.Get(c)
@@ -101,8 +100,8 @@ func (e *Engine) Put(c cid.Cid, value entry.Value) (bool, error) {
 	return e.valueStore.Put(c, value)
 }
 
-// PutMany stores one entry.Value for multiple CIDs
-func (e *Engine) PutMany(cids []cid.Cid, value entry.Value) error {
+// PutMany stores one indexer.Value for multiple CIDs
+func (e *Engine) PutMany(cids []cid.Cid, value indexer.Value) error {
 	if e.resultCache == nil {
 		return e.valueStore.PutMany(cids, value)
 	}
@@ -117,7 +116,7 @@ func (e *Engine) PutMany(cids []cid.Cid, value entry.Value) error {
 }
 
 // Remove removes a value for the specified CID
-func (e *Engine) Remove(c cid.Cid, value entry.Value) (bool, error) {
+func (e *Engine) Remove(c cid.Cid, value indexer.Value) (bool, error) {
 	ok, err := e.valueStore.Remove(c, value)
 	if err != nil {
 		return false, err
@@ -136,7 +135,7 @@ func (e *Engine) Remove(c cid.Cid, value entry.Value) (bool, error) {
 }
 
 // RemoveMany removes the specified value from multiple CIDs
-func (e *Engine) RemoveMany(cids []cid.Cid, value entry.Value) error {
+func (e *Engine) RemoveMany(cids []cid.Cid, value indexer.Value) error {
 	// Remove first from valueStore
 	err := e.valueStore.RemoveMany(cids, value)
 	if err != nil {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -1,6 +1,7 @@
-package indexer
+package engine
 
 import (
+	"github.com/filecoin-project/go-indexer-core"
 	"github.com/filecoin-project/go-indexer-core/cache"
 	"github.com/filecoin-project/go-indexer-core/entry"
 	"github.com/filecoin-project/go-indexer-core/store"
@@ -11,14 +12,18 @@ import (
 
 var log = logging.Logger("indexer-core")
 
-// Engine combines a result cache and a value store
+// Engine is an implementation of indexer.Interface that combines a result
+// cache and a value store
 type Engine struct {
 	resultCache cache.Interface
 	valueStore  store.Interface
 }
 
-// NewEngine creates a new Engine with the given result cache and value store
-func NewEngine(resultCache cache.Interface, valueStore store.Interface) *Engine {
+var _ indexer.Interface = &Engine{}
+
+// New implements the indexer.Interface.  It creates a new Engine with the
+// given result cache and value store
+func New(resultCache cache.Interface, valueStore store.Interface) *Engine {
 	if valueStore == nil {
 		panic("valueStore is required")
 	}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -166,10 +166,8 @@ func (e *Engine) RemoveProvider(providerID peer.ID) error {
 	return e.resultCache.RemoveProvider(providerID)
 }
 
-// Size returns the total storage capacity, in bytes, used to by the value
-// store.  This does not include any space used by the result cache, as it only
-// contains a limited quantity of results for previous queries, so is not
-// representative of the total amount of data stored by the indexer.
+// Size returns the total bytes of storage used by the value store to store the
+// indexed content.  This does not include memory used by the result cache.
 func (e *Engine) Size() (int64, error) {
 	return e.valueStore.Size()
 }

--- a/interface.go
+++ b/interface.go
@@ -1,0 +1,35 @@
+package indexer
+
+import (
+	"github.com/filecoin-project/go-indexer-core/entry"
+	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+type Interface interface {
+	// Get retrieves a slice of entry.Value for a CID
+	Get(c cid.Cid) ([]entry.Value, bool, error)
+
+	// Put stores a value for a CID if the value is not already stored.  New
+	// values are added to those that are already stored for the CID.
+	Put(c cid.Cid, value entry.Value) (bool, error)
+
+	// PutMany stores one entry.Value for multiple CIDs
+	PutMany(cids []cid.Cid, value entry.Value) error
+
+	// Remove removes a value for the specified CID
+	Remove(c cid.Cid, value entry.Value) (bool, error)
+
+	// RemoveMany removes the specified value from multiple CIDs
+	RemoveMany(cids []cid.Cid, value entry.Value) error
+
+	// RemoveProvider removes all values for specified provider.  This is used
+	// when a provider is no longer indexed by the indexer.
+	RemoveProvider(providerID peer.ID) error
+
+	// Size returns the total storage capacity, in bytes, used to by the value
+	// store.  This does not include any space used by the result cache, as it
+	// only contains a limited quantity of results for previous queries, so is
+	// not representative of the total amount of data stored by the indexer.
+	Size() (int64, error)
+}

--- a/interface.go
+++ b/interface.go
@@ -1,27 +1,26 @@
 package indexer
 
 import (
-	"github.com/filecoin-project/go-indexer-core/entry"
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
 type Interface interface {
-	// Get retrieves a slice of entry.Value for a CID
-	Get(c cid.Cid) ([]entry.Value, bool, error)
+	// Get retrieves a slice of Value for a CID
+	Get(c cid.Cid) ([]Value, bool, error)
 
 	// Put stores a value for a CID if the value is not already stored.  New
 	// values are added to those that are already stored for the CID.
-	Put(c cid.Cid, value entry.Value) (bool, error)
+	Put(c cid.Cid, value Value) (bool, error)
 
-	// PutMany stores one entry.Value for multiple CIDs
-	PutMany(cids []cid.Cid, value entry.Value) error
+	// PutMany stores one Value for multiple CIDs
+	PutMany(cids []cid.Cid, value Value) error
 
 	// Remove removes a value for the specified CID
-	Remove(c cid.Cid, value entry.Value) (bool, error)
+	Remove(c cid.Cid, value Value) (bool, error)
 
 	// RemoveMany removes the specified value from multiple CIDs
-	RemoveMany(cids []cid.Cid, value entry.Value) error
+	RemoveMany(cids []cid.Cid, value Value) error
 
 	// RemoveProvider removes all values for specified provider.  This is used
 	// when a provider is no longer indexed by the indexer.

--- a/interface.go
+++ b/interface.go
@@ -27,9 +27,10 @@ type Interface interface {
 	// when a provider is no longer indexed by the indexer.
 	RemoveProvider(providerID peer.ID) error
 
-	// Size returns the total storage capacity, in bytes, used to by the value
-	// store.  This does not include any space used by the result cache, as it
-	// only contains a limited quantity of results for previous queries, so is
-	// not representative of the total amount of data stored by the indexer.
+	// Size returns the total bytes of storage used to store the indexed
+	// content in persistent storage.  This does not include memory used by any
+	// in-memory cache that the indexer implementation may have, as that would
+	// only contain a limited quantity of data and not represent the total
+	// amount of data stored by the indexer.
 	Size() (int64, error)
 }

--- a/store/interface.go
+++ b/store/interface.go
@@ -1,7 +1,7 @@
 package store
 
 import (
-	"github.com/filecoin-project/go-indexer-core/entry"
+	"github.com/filecoin-project/go-indexer-core"
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p-core/peer"
 )
@@ -11,16 +11,16 @@ import (
 // limit.
 type Interface interface {
 	// Get retrieves a slice of values for a CID
-	Get(cid.Cid) ([]entry.Value, bool, error)
-	// Put stores an additional value for a CID if the entry is not already stored
-	Put(cid.Cid, entry.Value) (bool, error)
+	Get(cid.Cid) ([]indexer.Value, bool, error)
+	// Put stores an additional value for a CID if the value is not already stored
+	Put(cid.Cid, indexer.Value) (bool, error)
 	// PutMany stores a value for multiple CIDs
-	PutMany([]cid.Cid, entry.Value) error
+	PutMany([]cid.Cid, indexer.Value) error
 	// Remove removes a value for a CID
-	Remove(cid.Cid, entry.Value) (bool, error)
+	Remove(cid.Cid, indexer.Value) (bool, error)
 	// RemoveMany removes a value from multiple CIDs
-	RemoveMany([]cid.Cid, entry.Value) error
-	// RemoveProvider removes all entries for specified provider.  This is used
+	RemoveMany([]cid.Cid, indexer.Value) error
+	// RemoveProvider removes all values for specified provider.  This is used
 	// when a provider is no longer indexed by the indexer.
 	RemoveProvider(peer.ID) error
 	// Size returns the total storage capacity being used

--- a/store/storethehash/storethehash_test.go
+++ b/store/storethehash/storethehash_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/filecoin-project/go-indexer-core/entry"
+	"github.com/filecoin-project/go-indexer-core"
 	"github.com/filecoin-project/go-indexer-core/store"
 	"github.com/filecoin-project/go-indexer-core/store/storethehash"
 	"github.com/filecoin-project/go-indexer-core/store/test"
@@ -78,9 +78,9 @@ func TestPeriodicFlush(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	entry := entry.MakeValue(p, 0, cids[0].Bytes())
+	value := indexer.MakeValue(p, 0, cids[0].Bytes())
 	for _, c := range cids[1:] {
-		_, err = s.Put(c, entry)
+		_, err = s.Put(c, value)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -103,7 +103,7 @@ func TestPeriodicFlush(t *testing.T) {
 	if !found {
 		t.Fatal("Error finding single cid")
 	}
-	if !i[0].Equal(entry) {
+	if !i[0].Equal(value) {
 		t.Errorf("Got wrong value for single cid")
 	}
 

--- a/store/test/benchmarks.go
+++ b/store/test/benchmarks.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/filecoin-project/go-indexer-core/entry"
+	"github.com/filecoin-project/go-indexer-core"
 	"github.com/filecoin-project/go-indexer-core/store"
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -17,7 +17,7 @@ import (
 const (
 	testDataDir = "../test/test_data/"
 	testDataExt = ".data"
-	// protocol ID for IndexEntry metadata
+	// protocol ID for index.Value metadata
 	protocolID = 0
 )
 
@@ -42,8 +42,8 @@ func prepare(s store.Interface, size string, t *testing.T) {
 	go ReadCids(file, out, errOut)
 
 	for c := range out {
-		entry := entry.MakeValue(p, protocolID, c.Bytes())
-		_, err = s.Put(c, entry)
+		value := indexer.MakeValue(p, protocolID, c.Bytes())
+		_, err = s.Put(c, value)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -105,10 +105,10 @@ func BenchCidGet(s store.Interface, b *testing.B) {
 	}
 	p, _ := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
 
-	entry := entry.MakeValue(p, protocolID, cids[0].Bytes())
+	value := indexer.MakeValue(p, protocolID, cids[0].Bytes())
 
 	cids, _ = RandomCids(4096)
-	err = s.PutMany(cids, entry)
+	err = s.PutMany(cids, value)
 	if err != nil {
 		panic(err)
 	}
@@ -147,10 +147,10 @@ func BenchParallelCidGet(s store.Interface, b *testing.B) {
 	}
 	p, _ := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
 
-	entry := entry.MakeValue(p, protocolID, cids[0].Bytes())
+	value := indexer.MakeValue(p, protocolID, cids[0].Bytes())
 
 	cids, _ = RandomCids(4096)
-	err = s.PutMany(cids, entry)
+	err = s.PutMany(cids, value)
 	if err != nil {
 		panic(err)
 	}

--- a/value.go
+++ b/value.go
@@ -1,4 +1,4 @@
-package entry
+package indexer
 
 import (
 	"bytes"

--- a/value_test.go
+++ b/value_test.go
@@ -1,4 +1,4 @@
-package entry
+package indexer
 
 import (
 	"bytes"


### PR DESCRIPTION
This puts an interface for the indexer core at the top level of this repo and moves `Engine` into a sub-package, making it an implementation of the indexer interface.
