### PR TITLE
Store hashes from non-v0 CIDs in storethehash

### DIFF
--- a/store/storethehash/storethehash_test.go
+++ b/store/storethehash/storethehash_test.go
@@ -77,12 +77,13 @@ func TestPeriodicFlush(t *testing.T) {
 
 	value := indexer.MakeValue(p, 0, []byte(mhs[0]))
 
-	// Check that a non-v0 CID hash can be stored.
+	// Check that a v1 CID hash can be stored.
 	c, err := cid.Decode("baguqeeqqskyz3yh4jxnsdj57v5blazexyy")
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = s.Put(c.Hash(), value)
+	v1mh := c.Hash()
+	_, err = s.Put(v1mh, value)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,6 +114,17 @@ func TestPeriodicFlush(t *testing.T) {
 	}
 	if !i[0].Equal(value) {
 		t.Errorf("Got wrong value for single multihash")
+	}
+
+	i, found, err = s2.Get(v1mh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("Error finding single multihash from v1 CID")
+	}
+	if !i[0].Equal(value) {
+		t.Errorf("Got wrong value for single multihash from v1 CID")
 	}
 
 }

--- a/store/storethehash/storethehash_test.go
+++ b/store/storethehash/storethehash_test.go
@@ -10,7 +10,9 @@ import (
 	"github.com/filecoin-project/go-indexer-core/store"
 	"github.com/filecoin-project/go-indexer-core/store/storethehash"
 	"github.com/filecoin-project/go-indexer-core/store/test"
+	"github.com/ipfs/go-cid"
 	peer "github.com/libp2p/go-libp2p-core/peer"
+	//"github.com/multiformats/go-multihash"
 )
 
 func initSth(t *testing.T) store.Interface {
@@ -74,8 +76,19 @@ func TestPeriodicFlush(t *testing.T) {
 	}
 
 	value := indexer.MakeValue(p, 0, []byte(mhs[0]))
-	for _, c := range mhs[1:] {
-		_, err = s.Put(c, value)
+
+	// Check that a non-v0 CID hash can be stored.
+	c, err := cid.Decode("baguqeeqqskyz3yh4jxnsdj57v5blazexyy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.Put(c.Hash(), value)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, m := range mhs[1:] {
+		_, err = s.Put(m, value)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
**Fix inability to store hashes from non v0 CIDs**

Currently, go-storethehash can only store keys that are CIDs.  So, if a multihash is from a non-v0 CID this causes an error when trying to transform key bytes back into a CID (since the key bytes were a multihash and not a VID).

This PR fixes this by always creating a v1 CID from the multihash before storing it into storethehash.

Added unit test to test storing hash from v1 CID.  Previous unit tests did not detect the problem because they all used V0 CIDs, that have the same multihash value as the CID.