### PR TITLE
Expose iterators for the value store

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -69,6 +69,11 @@ func (e *Engine) Get(m multihash.Multihash) ([]indexer.Value, bool, error) {
 	return e.valueStore.Get(m)
 }
 
+// ForEach iterates multihashes in the value store, calling the provided function for each
+func (e *Engine) ForEach(iterFunc indexer.IterFunc) error {
+	return e.valueStore.ForEach(iterFunc)
+}
+
 // Put stores a value for a multihash if the value is not already stored.  New values
 // are added to those that are already stored for the multihash.
 func (e *Engine) Put(m multihash.Multihash, value indexer.Value) (bool, error) {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/ipfs/go-cid v0.1.0
 	github.com/ipfs/go-log/v2 v2.3.0
 	github.com/ipld/go-storethehash v0.0.0-20210915115016-46cc9b178292
-	github.com/libp2p/go-libp2p-core v0.9.0
+	github.com/libp2p/go-libp2p-core v0.10.0
 	github.com/multiformats/go-multihash v0.0.16
 	github.com/multiformats/go-varint v0.0.6
 )

--- a/go.sum
+++ b/go.sum
@@ -122,7 +122,6 @@ github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c/go.mod h1:sdx1xVM
 github.com/jbenet/go-temp-err-catcher v0.0.0-20150120210811-aac704a3f4f2/go.mod h1:8GXXJV31xl8whumTzdZsTt3RnUIiPqzkyf7mxToRCMs=
 github.com/jbenet/goprocess v0.0.0-20160826012719-b497e2f366b8/go.mod h1:Ly/wlsjFq/qrU3Rar62tu1gASgGw6chQbSh/XgIIXCY=
 github.com/jbenet/goprocess v0.1.3/go.mod h1:5yspPrukOVuOLORacaBi858NqyClJPQxYZlqdZVfqY4=
-github.com/jbenet/goprocess v0.1.4/go.mod h1:5yspPrukOVuOLORacaBi858NqyClJPQxYZlqdZVfqY4=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
 github.com/jtolds/gls v4.2.1+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
@@ -152,8 +151,8 @@ github.com/libp2p/go-libp2p-circuit v0.1.0/go.mod h1:Ahq4cY3V9VJcHcn1SBXjr78AbFk
 github.com/libp2p/go-libp2p-core v0.0.1/go.mod h1:g/VxnTZ/1ygHxH3dKok7Vno1VfpvGcGip57wjTU4fco=
 github.com/libp2p/go-libp2p-core v0.0.2/go.mod h1:9dAcntw/n46XycV4RnlBq3BpgrmyUi9LuoTNdPrbUco=
 github.com/libp2p/go-libp2p-core v0.0.3/go.mod h1:j+YQMNz9WNSkNezXOsahp9kwZBKBvxLpKD316QWSJXE=
-github.com/libp2p/go-libp2p-core v0.9.0 h1:t97Mv0LIBZlP2FXVRNKKVzHJCIjbIWGxYptGId4+htU=
-github.com/libp2p/go-libp2p-core v0.9.0/go.mod h1:ESsbz31oC3C1AvMJoGx26RTuCkNhmkSRCqZ0kQtJ2/8=
+github.com/libp2p/go-libp2p-core v0.10.0 h1:jFy7v5Muq58GTeYkPhGzIH8Qq4BFfziqc0ixPd/pP9k=
+github.com/libp2p/go-libp2p-core v0.10.0/go.mod h1:ECdxehoYosLYHgDDFa2N4yE8Y7aQRAMf0sX9mf2sbGg=
 github.com/libp2p/go-libp2p-crypto v0.1.0/go.mod h1:sPUokVISZiy+nNuTTH/TY+leRSxnFj/2GLjtOTW90hI=
 github.com/libp2p/go-libp2p-discovery v0.1.0/go.mod h1:4F/x+aldVHjHDHuX85x1zWoFTGElt8HnoDzwkFZm29g=
 github.com/libp2p/go-libp2p-loggables v0.1.0/go.mod h1:EyumB2Y6PrYjr55Q3/tiJ/o3xoDasoRYM7nOzEpoa90=
@@ -263,8 +262,9 @@ github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572/go.mod h1:w
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/warpfork/go-wish v0.0.0-20180510122957-5ad1f5abf436/go.mod h1:x6AKhvSSexNrVSrViXSHUEbICjmGXhtgABaHIySUSGw=
 github.com/warpfork/go-wish v0.0.0-20190328234359-8b3e70f8e830/go.mod h1:x6AKhvSSexNrVSrViXSHUEbICjmGXhtgABaHIySUSGw=
@@ -350,5 +350,7 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.1-2019.2.3 h1:3JgtbtFHMiCmsznwGVTUWbgGov+pVqnlf1dEJTNAXeM=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=

--- a/interface.go
+++ b/interface.go
@@ -16,6 +16,8 @@ type Interface interface {
 
 	// ForEach iterates multihashes in the value store, calling the provided
 	// function for each multihash index visited
+	//
+	// It should be assumed that any write operation invalidates iteration
 	ForEach(IterFunc) error
 
 	// Put stores a value for a multihash if the value is not already stored.

--- a/interface.go
+++ b/interface.go
@@ -5,9 +5,18 @@ import (
 	"github.com/multiformats/go-multihash"
 )
 
+// IterFunc is the type of the function called for each multihash index visited by ForEach.
+//
+// If the function returns true, ForEach stops immediately and returns.
+type IterFunc func(multihash.Multihash, []Value) bool
+
 type Interface interface {
 	// Get retrieves a slice of Value for a multihash
 	Get(multihash.Multihash) ([]Value, bool, error)
+
+	// ForEach iterates multihashes in the value store, calling the provided
+	// function for each multihash index visited
+	ForEach(IterFunc) error
 
 	// Put stores a value for a multihash if the value is not already stored.
 	// New values are added to those that are already stored for the multihash.

--- a/store/interface.go
+++ b/store/interface.go
@@ -12,6 +12,9 @@ import (
 type Interface interface {
 	// Get retrieves a slice of values for a multihash
 	Get(multihash.Multihash) ([]indexer.Value, bool, error)
+	// ForEach iterates multihashes, calling the provided function for each
+	// multihash index visited
+	ForEach(indexer.IterFunc) error
 	// Put stores an additional value for a multihash if the value is not already stored
 	Put(multihash.Multihash, indexer.Value) (bool, error)
 	// PutMany stores a value for multiple multihashes

--- a/store/pogreb/pogreb.go
+++ b/store/pogreb/pogreb.go
@@ -65,7 +65,10 @@ func (s *pStorage) get(k []byte) ([]indexer.Value, bool, error) {
 }
 
 func (s *pStorage) ForEach(iterFunc indexer.IterFunc) error {
-	s.store.Sync()
+	err := s.store.Sync()
+	if err != nil {
+		return err
+	}
 	it := s.store.Items()
 	for {
 		key, val, err := it.Next()

--- a/store/pogreb/pogreb.go
+++ b/store/pogreb/pogreb.go
@@ -56,12 +56,37 @@ func (s *pStorage) get(k []byte) ([]indexer.Value, bool, error) {
 		return nil, false, nil
 	}
 
-	out, err := indexer.Unmarshal(value)
+	out, err := indexer.UnmarshalValues(value)
 	if err != nil {
 		return nil, false, err
 	}
 	return out, true, nil
 
+}
+
+func (s *pStorage) ForEach(iterFunc indexer.IterFunc) error {
+	s.store.Sync()
+	it := s.store.Items()
+	for {
+		key, val, err := it.Next()
+		if err != nil {
+			if err == pogreb.ErrIterationDone {
+				break
+			}
+			return err
+		}
+
+		values, err := indexer.UnmarshalValues(val)
+		if err != nil {
+			return err
+		}
+
+		if iterFunc(multihash.Multihash(key), values) {
+			break
+		}
+	}
+
+	return nil
 }
 
 func (s *pStorage) Put(m multihash.Multihash, value indexer.Value) (bool, error) {
@@ -83,7 +108,7 @@ func (s *pStorage) put(k []byte, in indexer.Value) (bool, error) {
 	}
 
 	li := append(old, in)
-	b, err := indexer.Marshal(li)
+	b, err := indexer.MarshalValues(li)
 	if err != nil {
 		return false, err
 	}
@@ -196,7 +221,7 @@ func (s *pStorage) removeValue(k []byte, value indexer.Value, stored []indexer.V
 			// else remove from value and put updated structure
 			stored[i] = stored[len(stored)-1]
 			stored[len(stored)-1] = indexer.Value{}
-			b, err := indexer.Marshal(stored[:len(stored)-1])
+			b, err := indexer.MarshalValues(stored[:len(stored)-1])
 			if err != nil {
 				return false, err
 			}

--- a/store/storethehash/storethehash.go
+++ b/store/storethehash/storethehash.go
@@ -82,7 +82,10 @@ func (s *sthStorage) ForEach(iterFunc indexer.IterFunc) error {
 	// It is necessary to do both flush and sync before creating an iterator to
 	// read values that have not been written to file yet
 	s.primary.Flush()
-	s.primary.Sync()
+	err := s.primary.Sync()
+	if err != nil {
+		return err
+	}
 	iter, err := s.primary.Iter()
 	if err != nil {
 		return err
@@ -109,7 +112,7 @@ func (s *sthStorage) ForEach(iterFunc indexer.IterFunc) error {
 		uniqKeys[string(key)] = struct{}{}
 	}
 
-	for key, _ := range uniqKeys {
+	for key := range uniqKeys {
 		kb := []byte(key)
 		values, ok, err := s.get(kb)
 		if err != nil {

--- a/store/storethehash/storethehash.go
+++ b/store/storethehash/storethehash.go
@@ -1,6 +1,7 @@
 package storethehash
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -26,6 +27,8 @@ type sthStorage struct {
 	dir   string
 	store *sth.Store
 	mlk   *kmutex.Kmutex
+
+	primary *mhprimary.MultihashPrimary
 }
 
 func New(dir string) (*sthStorage, error) {
@@ -47,9 +50,10 @@ func New(dir string) (*sthStorage, error) {
 	}
 	s.Start()
 	return &sthStorage{
-		dir:   dir,
-		store: s,
-		mlk:   kmutex.New(),
+		dir:     dir,
+		store:   s,
+		mlk:     kmutex.New(),
+		primary: primary,
 	}, nil
 }
 
@@ -66,12 +70,61 @@ func (s *sthStorage) get(k []byte) ([]indexer.Value, bool, error) {
 		return nil, false, nil
 	}
 
-	out, err := indexer.Unmarshal(value)
+	out, err := indexer.UnmarshalValues(value)
 	if err != nil {
 		return nil, false, err
 	}
 	return out, true, nil
 
+}
+
+func (s *sthStorage) ForEach(iterFunc indexer.IterFunc) error {
+	// It is necessary to do both flush and sync before creating an iterator to
+	// read values that have not been written to file yet
+	s.primary.Flush()
+	s.primary.Sync()
+	iter, err := s.primary.Iter()
+	if err != nil {
+		return err
+	}
+
+	// Create a list of unique keys, and then call get for each unique key.
+	//
+	// This is necessary because the primary iterator returns all versions of
+	// each index.  If a key has been updated with new values, the iterator
+	// returns the key with the original values, then again with the values for
+	// the next update, and so on for as many updates a there were for a key.
+	//
+	// TODO: if there are many keys, this could take up too much memory.  Need
+	// a better iterator in storethehash.
+	uniqKeys := map[string]struct{}{}
+	for {
+		key, _, err := iter.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+		uniqKeys[string(key)] = struct{}{}
+	}
+
+	for key, _ := range uniqKeys {
+		kb := []byte(key)
+		values, ok, err := s.get(kb)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			continue
+		}
+
+		if iterFunc(multihash.Multihash(kb), values) {
+			break
+		}
+	}
+
+	return nil
 }
 
 func (s *sthStorage) Put(m multihash.Multihash, value indexer.Value) (bool, error) {
@@ -98,7 +151,7 @@ func (s *sthStorage) put(k []byte, in indexer.Value) (bool, error) {
 	}
 
 	li := append(old, in)
-	b, err := indexer.Marshal(li)
+	b, err := indexer.MarshalValues(li)
 	if err != nil {
 		return false, err
 	}
@@ -215,7 +268,7 @@ func (s *sthStorage) removeValue(k []byte, value indexer.Value, stored []indexer
 			// else remove from value and put updated structure
 			stored[i] = stored[len(stored)-1]
 			stored[len(stored)-1] = indexer.Value{}
-			b, err := indexer.Marshal(stored[:len(stored)-1])
+			b, err := indexer.MarshalValues(stored[:len(stored)-1])
 			if err != nil {
 				return false, err
 			}

--- a/store/storethehash/storethehash_test.go
+++ b/store/storethehash/storethehash_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/filecoin-project/go-indexer-core/store"
 	"github.com/filecoin-project/go-indexer-core/store/storethehash"
 	"github.com/filecoin-project/go-indexer-core/store/test"
-	"github.com/ipfs/go-cid"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 	//"github.com/multiformats/go-multihash"
 )
@@ -76,18 +75,6 @@ func TestPeriodicFlush(t *testing.T) {
 	}
 
 	value := indexer.MakeValue(p, 0, []byte(mhs[0]))
-
-	// Check that a v1 CID hash can be stored.
-	c, err := cid.Decode("baguqeeqqskyz3yh4jxnsdj57v5blazexyy")
-	if err != nil {
-		t.Fatal(err)
-	}
-	v1mh := c.Hash()
-	_, err = s.Put(v1mh, value)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	for _, m := range mhs[1:] {
 		_, err = s.Put(m, value)
 		if err != nil {
@@ -115,16 +102,4 @@ func TestPeriodicFlush(t *testing.T) {
 	if !i[0].Equal(value) {
 		t.Errorf("Got wrong value for single multihash")
 	}
-
-	i, found, err = s2.Get(v1mh)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !found {
-		t.Fatal("Error finding single multihash from v1 CID")
-	}
-	if !i[0].Equal(value) {
-		t.Errorf("Got wrong value for single multihash from v1 CID")
-	}
-
 }

--- a/value.go
+++ b/value.go
@@ -56,12 +56,12 @@ func encodeMetadata(protocol uint64, data []byte) []byte {
 // Marshal serializes a Value list for storage
 // TODO: Switch from JSON to a more efficient serialization
 // format once we figure out the right data structure?
-func Marshal(li []Value) ([]byte, error) {
+func MarshalValues(li []Value) ([]byte, error) {
 	return json.Marshal(&li)
 }
 
 // Unmarshal serialized Value list
-func Unmarshal(b []byte) ([]Value, error) {
+func UnmarshalValues(b []byte) ([]Value, error) {
 	li := []Value{}
 	err := json.Unmarshal(b, &li)
 	return li, err


### PR DESCRIPTION
The indexer core now has a ForEach API that allows iteration over the values in the value store.  Each value store implementation must support a ForEach API to satisfy the Store interface.

This fixes issue #20 

Attn. reviewers, please read [this comment](https://github.com/filecoin-project/go-indexer-core/pull/21/files#diff-b0444f44707cb9e7710ecf06ea6bfeea3879a6e115be960097dc85070db65e62R94-R102) and consider alternatives.