### PR TITLE
Replace keyed mutex implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.16
 
 require (
 	github.com/akrylysov/pogreb v0.10.1
+	github.com/gammazero/keymutex v0.0.0-20210923122432-72239b58243f
 	github.com/gammazero/radixtree v0.2.5
-	github.com/im7mortal/kmutex v1.0.1
 	github.com/ipfs/go-cid v0.1.0
 	github.com/ipfs/go-log/v2 v2.3.0
 	github.com/ipld/go-storethehash v0.0.0-20210915160027-d72ca9b0968c

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/dgraph-io/badger v1.5.5-0.20190226225317-8115aed38f8f/go.mod h1:VZxzA
 github.com/dgryski/go-farm v0.0.0-20190104051053-3adb47b1fb0f/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/gammazero/keymutex v0.0.0-20210923122432-72239b58243f h1:mNk2SmvPE/u/HNSvUnPaJhElkkTU54OHT4Vg75FYBJ0=
+github.com/gammazero/keymutex v0.0.0-20210923122432-72239b58243f/go.mod h1:qtzWCCLMisQUmVa4dvqHVgwfh4BP2YB7JxNDGXnsKrs=
 github.com/gammazero/radixtree v0.2.5 h1:muPQ4eEgCkUymFWPiVQRuXOQv4IhWg8YXH2r71MoqPM=
 github.com/gammazero/radixtree v0.2.5/go.mod h1:VPqqCDZ3YZZxAzUUsIF/ytFBigVWV7JIV1Stld8hri0=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
@@ -51,8 +53,6 @@ github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uG
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huin/goupnp v1.0.0/go.mod h1:n9v9KO1tAxYH82qOn+UTIFQDmx5n1Zxd/ClZDMX7Bnc=
 github.com/huin/goutil v0.0.0-20170803182201-1ca381bf3150/go.mod h1:PpLOETDnJ0o3iZrZfqZzyLl6l7F3c6L1oWn7OICBi6o=
-github.com/im7mortal/kmutex v1.0.1 h1:zAACzjwD+OEknDqnLdvRa/BhzFM872EBwKijviGLc9Q=
-github.com/im7mortal/kmutex v1.0.1/go.mod h1:f71c/Ugk/+58OHRAgvgzPP3QEiWGUjK13fd8ozfKWdo=
 github.com/ipfs/bbloom v0.0.1/go.mod h1:oqo8CVWsJFMOZqTglBG4wydCE4IQA/G2/SEofB0rjUI=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
 github.com/ipfs/go-bitswap v0.1.0/go.mod h1:FFJEf18E9izuCqUtHxbWEvq+reg7o4CW5wSAE1wsxj0=

--- a/store/pogreb/pogreb.go
+++ b/store/pogreb/pogreb.go
@@ -15,7 +15,7 @@ import (
 	"github.com/akrylysov/pogreb"
 	"github.com/filecoin-project/go-indexer-core"
 	"github.com/filecoin-project/go-indexer-core/store"
-	"github.com/im7mortal/kmutex"
+	"github.com/gammazero/keymutex"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 	"github.com/multiformats/go-multihash"
 )
@@ -27,7 +27,7 @@ const DefaultSyncInterval = time.Second
 type pStorage struct {
 	dir   string
 	store *pogreb.DB
-	mlk   *kmutex.Kmutex
+	mlk   *keymutex.KeyMutex
 }
 
 type pogrebIter struct {
@@ -44,7 +44,7 @@ func New(dir string) (*pStorage, error) {
 	return &pStorage{
 		dir:   dir,
 		store: s,
-		mlk:   kmutex.New(),
+		mlk:   keymutex.New(0),
 	}, nil
 }
 

--- a/store/storethehash/storethehash.go
+++ b/store/storethehash/storethehash.go
@@ -12,7 +12,7 @@ import (
 	mhprimary "github.com/ipld/go-storethehash/store/primary/multihash"
 	"github.com/multiformats/go-multihash"
 
-	"github.com/im7mortal/kmutex"
+	"github.com/gammazero/keymutex"
 	sth "github.com/ipld/go-storethehash/store"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 )
@@ -27,7 +27,7 @@ const DefaultSyncInterval = time.Second
 type sthStorage struct {
 	dir   string
 	store *sth.Store
-	mlk   *kmutex.Kmutex
+	mlk   *keymutex.KeyMutex
 
 	primary *mhprimary.MultihashPrimary
 }
@@ -59,7 +59,7 @@ func New(dir string) (*sthStorage, error) {
 	return &sthStorage{
 		dir:     dir,
 		store:   s,
-		mlk:     kmutex.New(),
+		mlk:     keymutex.New(0),
 		primary: primary,
 	}, nil
 }


### PR DESCRIPTION
- The previous implementation had a flaw that could lead to deadlock
- The new implementation uses a fixes set of locks and eliminates having a map that continues to grow over time