### PR TITLE
Make a Metadata type that contains ProtocolID and Data

### DIFF
--- a/cache/radixcache/radixcache.go
+++ b/cache/radixcache/radixcache.go
@@ -348,10 +348,9 @@ func (c *radixCache) internValue(value *indexer.Value, updateMeta, saveNew bool)
 	if found {
 		// The provided value has matching ProviderID and ContextID but
 		// different Metadata.  Treat this as an update.
-		if updateMeta && !bytes.Equal(v.Metadata, value.Metadata) {
-			metadata := make([]byte, len(value.Metadata))
-			copy(metadata, value.Metadata)
-			v.Metadata = metadata
+		if updateMeta && !bytes.Equal(v.MetadataBytes, value.MetadataBytes) {
+			v.MetadataBytes = make([]byte, len(value.MetadataBytes))
+			copy(v.MetadataBytes, value.MetadataBytes)
 		}
 		return v
 	}

--- a/metadata.go
+++ b/metadata.go
@@ -1,0 +1,45 @@
+package indexer
+
+import (
+	"bytes"
+
+	"github.com/multiformats/go-varint"
+)
+
+// Metadata is data that provides information about retrieving
+// data for an index, from a particular provider.
+type Metadata struct {
+	// ProtocolID defines the protocol used for data retrieval.
+	ProtocolID uint64
+	// Data is specific to the identified protocol, and provides data, or a
+	// link to data, necessary for retrieval.
+	Data []byte
+}
+
+// Equal determines if two Metadata values are equal.
+func (m Metadata) Equal(other Metadata) bool {
+	return m.ProtocolID == other.ProtocolID && bytes.Equal(m.Data, other.Data)
+}
+
+// EncodeMetadata serializes Metadata to []byte.
+func EncodeMetadata(m Metadata) []byte {
+	varintSize := varint.UvarintSize(m.ProtocolID)
+	buf := make([]byte, varintSize+len(m.Data))
+	varint.PutUvarint(buf, m.ProtocolID)
+	if len(m.Data) != 0 {
+		copy(buf[varintSize:], m.Data)
+	}
+	return buf
+}
+
+// DecodeMetadata deserializes []byte into Metadata.
+func DecodeMetadata(data []byte) (Metadata, error) {
+	protocol, len, err := varint.FromUvarint(data)
+	if err != nil {
+		return Metadata{}, err
+	}
+	return Metadata{
+		ProtocolID: protocol,
+		Data:       data[len:],
+	}, nil
+}

--- a/store/memory/memory.go
+++ b/store/memory/memory.go
@@ -63,7 +63,7 @@ func (s *memoryStore) Get(m multihash.Multihash) ([]indexer.Value, bool, error) 
 }
 
 func (s *memoryStore) Put(value indexer.Value, mhs ...multihash.Multihash) error {
-	if len(value.Metadata) == 0 {
+	if len(value.MetadataBytes) == 0 {
 		return errors.New("value missing metadata")
 	}
 
@@ -240,10 +240,9 @@ func (s *memoryStore) internValue(value *indexer.Value, saveNew bool) *indexer.V
 	if found {
 		// The provided value has matching ProviderID and ContextID but
 		// different Metadata.  Treat this as an update.
-		if !bytes.Equal(v.Metadata, value.Metadata) {
-			metadata := make([]byte, len(value.Metadata))
-			copy(metadata, value.Metadata)
-			v.Metadata = metadata
+		if !bytes.Equal(v.MetadataBytes, value.MetadataBytes) {
+			v.MetadataBytes = make([]byte, len(value.MetadataBytes))
+			copy(v.MetadataBytes, value.MetadataBytes)
 		}
 		return v
 	}

--- a/value_test.go
+++ b/value_test.go
@@ -18,7 +18,7 @@ func TestPutGetData(t *testing.T) {
 	var value Value
 
 	value.PutData(testProtoID, testData)
-	if len(value.Metadata) == 0 {
+	if len(value.MetadataBytes) == 0 {
 		t.Fatal("did not encode metadata")
 	}
 
@@ -40,11 +40,18 @@ func TestEqual(t *testing.T) {
 	if !value1.Equal(value2) {
 		t.Fatal("values are not equal")
 	}
+	if !value1.Match(value1) {
+		t.Fatal("values do not match")
+	}
 
 	// Changing provider ID should make values unequal
 	value2 = MakeValue(p2, testCtxID, testProtoID, testData)
 	if value1.Equal(value2) {
 		t.Fatal("values are equal")
+	}
+	// Changing provider ID should make values not match
+	if value1.Match(value2) {
+		t.Fatal("values match")
 	}
 
 	// Changing context ID should make values unequal
@@ -52,16 +59,28 @@ func TestEqual(t *testing.T) {
 	if value1.Equal(value2) {
 		t.Fatal("values are equal")
 	}
+	// Changing context ID should make values not match
+	if value1.Match(value2) {
+		t.Fatal("values match")
+	}
 
 	// Changing protocol ID should make values unequal
 	value2 = MakeValue(p1, testCtxID, testProtoID+1, testData)
 	if value1.Equal(value2) {
 		t.Fatal("values are equal")
 	}
+	// Changing protocol ID should not affect match
+	if !value1.Match(value2) {
+		t.Fatal("values do not match")
+	}
 
 	// Changing metadata should make values unequal
 	value2 = MakeValue(p1, testCtxID, testProtoID, []byte("some dataX"))
 	if value1.Equal(value2) {
 		t.Fatal("values are equal")
+	}
+	// Changing metadata should not affect match
+	if !value1.Match(value2) {
+		t.Fatal("values do not match")
 	}
 }


### PR DESCRIPTION
There is now a `Metadata` type that makes it explicit that metadata is composed of protocol id and data.  The `indexer.Value` has a `MetadataBytes` member, which is the serialized form of a `Metadata` instance.  This is because metadata is opaque to the indexer, and the indexer should never need to deal with the components of metadata. The only time conversion to/from `Multihash` and `[]byte` is needed is at the interface between the provider and indexer.  Therefore the `indexer.Value` holds the serialized form, so it is explicitly opaque to the indexer.

Clients to the indexer will not deal with a `indexer.Value` object, and therefore will not see the serialized form of `Metadata`. Instead, they will see the deserialized `Metadata` in their client interfaces.  For example, [this here](https://github.com/filecoin-project/storetheindex/blob/no-spearate-provider-addrs/api/v0/finder/model/model.go#L25) will become a `indexer.Metatada` type.

