### PR TITLE
Implement store.RemoveProvider() for all value stores

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -171,6 +171,9 @@ func TestRemoveProvider(t *testing.T) {
 		t.Fatal(err)
 	}
 	prov2, err := peer.Decode("12D3KooWD1XypSuBmhebQcvq7Sf1XJZ1hKSfYCED4w6eyxhzwqnV")
+	if err != nil {
+		t.Fatal(err)
+	}
 	ctx1id := []byte("ctxid-1")
 	ctx2id := []byte("ctxid-2")
 	value1 := indexer.Value{

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -164,7 +164,7 @@ func TestPassthrough(t *testing.T) {
 }
 
 func TestRemoveProvider(t *testing.T) {
-	eng := initEngine(t, true)
+	eng := initEngine(t, true, true)
 
 	prov1, err := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
 	if err != nil {
@@ -213,12 +213,6 @@ func TestRemoveProvider(t *testing.T) {
 	}
 	if err = eng.Put(value3, batch3...); err != nil {
 		t.Fatal(err)
-	}
-	for i := range mhs {
-		_, _, err = eng.Get(mhs[i])
-		if err != nil {
-			t.Fatal(err)
-		}
 	}
 
 	stats := eng.resultCache.Stats()
@@ -337,7 +331,7 @@ func TestCacheOnPut(t *testing.T) {
 }
 
 func TestRemoveProviderContext(t *testing.T) {
-	eng := initEngine(t, true)
+	eng := initEngine(t, true, true)
 
 	// Create new valid peer.ID
 	prov1, err := peer.Decode("12D3KooWKRyzVWW6ChFjQjK4miCty85Niy48tpPV95XdKu1BcvMA")
@@ -391,12 +385,6 @@ func TestRemoveProviderContext(t *testing.T) {
 	}
 	if err = eng.Put(value3, batch3...); err != nil {
 		t.Fatal(err)
-	}
-	for i := range mhs {
-		_, _, err = eng.Get(mhs[i])
-		if err != nil {
-			t.Fatal(err)
-		}
 	}
 
 	// Verify starting with correct values

--- a/store/memory/memory.go
+++ b/store/memory/memory.go
@@ -306,16 +306,23 @@ func (s *memoryStore) removeProviderValues(providerID peer.ID) {
 
 	s.rtree.Walk("", func(k string, v interface{}) bool {
 		values := v.([]*indexer.Value)
-		for i := range values {
+		for i := 0; i < len(values); {
 			if providerID == values[i].ProviderID {
 				if len(values) == 1 {
-					deletes = append(deletes, k)
-				} else {
-					values[i] = values[len(values)-1]
-					values[len(values)-1] = nil
-					s.rtree.Put(k, values[:len(values)-1])
+					values = nil
+					break
 				}
+				values[i] = values[len(values)-1]
+				values[len(values)-1] = nil
+				values = values[:len(values)-1]
+				continue
 			}
+			i++
+		}
+		if len(values) == 0 {
+			deletes = append(deletes, k)
+		} else {
+			s.rtree.Put(k, values)
 		}
 		return false
 	})

--- a/store/memory/memory_test.go
+++ b/store/memory/memory_test.go
@@ -26,3 +26,8 @@ func TestRemoveProviderContext(t *testing.T) {
 	s := memory.New()
 	test.RemoveProviderContextTest(t, s)
 }
+
+func TestRemoveProvider(t *testing.T) {
+	s := memory.New()
+	test.RemoveProviderTest(t, s)
+}

--- a/store/pogreb/pogreb.go
+++ b/store/pogreb/pogreb.go
@@ -103,7 +103,7 @@ func (s *pStorage) RemoveProvider(providerID peer.ID) error {
 		key, val, err := iter.Next()
 		if err != nil {
 			if err == pogreb.ErrIterationDone {
-				return nil
+				break
 			}
 			return err
 		}
@@ -160,10 +160,6 @@ func (s *pStorage) RemoveProvider(providerID peer.ID) error {
 		for i := range vdel {
 			valsToDel[string(vdel[i].ContextID)] = struct{}{}
 		}
-	}
-
-	if len(valsToDel) == 0 {
-		return nil
 	}
 
 	// Delete the metadata for each value.

--- a/store/pogreb/pogreb_test.go
+++ b/store/pogreb/pogreb_test.go
@@ -63,6 +63,13 @@ func TestRemoveProviderContext(t *testing.T) {
 	test.RemoveProviderContextTest(t, s)
 }
 
+func TestRemoveProvider(t *testing.T) {
+	skipIf32bit(t)
+
+	s := initPogreb(t)
+	test.RemoveProviderTest(t, s)
+}
+
 func skipIf32bit(t *testing.T) {
 	if runtime.GOARCH == "386" {
 		t.Skip("Pogreb cannot use GOARCH=386")

--- a/store/storethehash/storethehash.go
+++ b/store/storethehash/storethehash.go
@@ -106,12 +106,116 @@ func (s *sthStorage) Remove(value indexer.Value, mhs ...multihash.Multihash) err
 }
 
 func (s *sthStorage) RemoveProvider(providerID peer.ID) error {
-	// NOTE: There is no straightforward way of implementing this
-	// batch remove. We can either regenerate the index from
-	// the original data, or iterate through the whole the whole primary storage
-	// inspecting all values for the provider in multihashes.
-	// Deferring to the future
-	panic("not implemented")
+	s.Flush()
+	iter, err := s.primary.Iter()
+	if err != nil {
+		return err
+	}
+
+	uniqKeys := map[string]struct{}{}
+	valsToDel := map[string]struct{}{}
+
+	s.mdLock.Lock()
+	defer s.mdLock.Unlock()
+
+	for {
+		key, _, err := iter.Next()
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+
+		// Decode the key and see if it is key.
+		dm, err := multihash.Decode(key)
+		if err != nil {
+			return err
+		}
+		if !bytes.HasPrefix(dm.Digest, indexKeyPrefix) {
+			// Key does not have index prefix, so is not an index key.
+			continue
+		}
+
+		origMultihash := multihash.Multihash(dm.Digest[len(indexKeyPrefix):])
+		k := string(origMultihash)
+		_, found := uniqKeys[k]
+		if found {
+			continue
+		}
+		uniqKeys[k] = struct{}{}
+
+		valueData, found, err := s.store.Get(multihash.Multihash(key))
+		if err != nil {
+			return err
+		}
+		if !found {
+			continue
+		}
+		values, err := indexer.UnmarshalValues(valueData)
+		if err != nil {
+			return err
+		}
+
+		// Separate values into those to remove and those to keep.
+		var vdel, vkeep []indexer.Value
+		for i := range values {
+			if values[i].ProviderID == providerID {
+				vdel = append(vdel, values[i])
+			} else {
+				vkeep = append(vkeep, values[i])
+			}
+		}
+
+		if len(vdel) == 0 {
+			continue
+		}
+
+		// If there are no values to keep, then remove the index.  Otherwise,
+		// update the index to have the remaining values.
+		if len(vkeep) == 0 {
+			_, err = s.store.Remove(key)
+			if err != nil {
+				return err
+			}
+		} else {
+			// store the list of value keys for the multihash
+			b, err := indexer.MarshalValues(vkeep)
+			if err != nil {
+				return err
+			}
+			err = s.store.Put(key, b)
+			if err != nil {
+				return err
+			}
+		}
+
+		for i := range vdel {
+			valsToDel[string(vdel[i].ContextID)] = struct{}{}
+		}
+	}
+
+	if len(valsToDel) == 0 {
+		return nil
+	}
+
+	// Delete the metadata for each value.
+	var buf bytes.Buffer
+	for ctxid := range valsToDel {
+		buf.WriteString(ctxid)
+		mdKey := makeMetadataKey(indexer.Value{
+			ProviderID: providerID,
+			ContextID:  buf.Bytes(),
+		})
+		// Remove metadata.
+		_, err = s.store.Remove(mdKey)
+		if err != nil {
+			return err
+		}
+		buf.Reset()
+	}
+
+	return nil
 }
 
 func (s *sthStorage) RemoveProviderContext(providerID peer.ID, contextID []byte) error {

--- a/store/storethehash/storethehash.go
+++ b/store/storethehash/storethehash.go
@@ -122,7 +122,7 @@ func (s *sthStorage) RemoveProvider(providerID peer.ID) error {
 		key, _, err := iter.Next()
 		if err != nil {
 			if err == io.EOF {
-				return nil
+				break
 			}
 			return err
 		}
@@ -193,10 +193,6 @@ func (s *sthStorage) RemoveProvider(providerID peer.ID) error {
 		for i := range vdel {
 			valsToDel[string(vdel[i].ContextID)] = struct{}{}
 		}
-	}
-
-	if len(valsToDel) == 0 {
-		return nil
 	}
 
 	// Delete the metadata for each value.

--- a/store/storethehash/storethehash_test.go
+++ b/store/storethehash/storethehash_test.go
@@ -50,6 +50,11 @@ func TestRemoveProviderContext(t *testing.T) {
 	test.RemoveProviderContextTest(t, s)
 }
 
+func TestRemoveProvider(t *testing.T) {
+	s := initSth(t)
+	test.RemoveProviderTest(t, s)
+}
+
 func TestParallel(t *testing.T) {
 	s := initSth(t)
 	test.ParallelUpdateTest(t, s)

--- a/store/test/tests.go
+++ b/store/test/tests.go
@@ -550,14 +550,14 @@ func RemoveProviderTest(t *testing.T, s indexer.Interface) {
 	if found {
 		t.Fatal("multihash should have been removed")
 	}
-	vals, found, err := s.Get(mhs[5])
+	_, found, err = s.Get(mhs[5])
 	if err != nil {
 		t.Fatal(err)
 	}
 	if found {
 		t.Fatal("multihash should have been removed")
 	}
-	vals, found, err = s.Get(mhs[10])
+	vals, found, err := s.Get(mhs[10])
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
All value stores have a RemoveProvider implementation.  This walks through all indexes and removes values from the specified provider, and cleans up indexes that are left without any value.

Fixes #35