### PR TITLE
Fix storethehash regression

### DIFF
--- a/store/test/tests.go
+++ b/store/test/tests.go
@@ -142,6 +142,13 @@ func E2ETest(t *testing.T, s indexer.Interface) {
 	if indexCount != len(batch)+1 {
 		t.Errorf("Wrong iteration count: expected %d, got %d", len(batch)+1, indexCount)
 	}
+	for i := range batch {
+		b58 := batch[i].B58String()
+		_, ok := seen[b58]
+		if !ok {
+			t.Fatalf("Did not iterate multihash %s", b58)
+		}
+	}
 
 	_, _, err = iter.Next()
 	if err != io.EOF {


### PR DESCRIPTION
The storethehash valuestore expects the first n bits of the multihash digest to be hash data (even distribution of values).  Adding a fixed value prefix caused a tragic performance regression.  The prefix was used to differentiate index keys from metadata keys.  This change fixes the problem by putting the identifier value at the end of the hash data.