### PR TITLE
Improve storage use by changing how values are stored

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -160,6 +160,7 @@ func (e *Engine) RemoveProvider(providerID peer.ID) error {
 
 	e.resultCache.RemoveProvider(providerID)
 	e.updateCacheStats()
+	stats.Record(context.Background(), metrics.RemovedProviders.M(1))
 	return nil
 }
 
@@ -200,7 +201,7 @@ func (e *Engine) updateCacheStats() {
 	st := e.resultCache.Stats()
 	var ms []stats.Measurement
 	if st.Indexes != e.prevCacheStats.Indexes {
-		ms = append(ms, metrics.CacheItems.M(int64(st.Indexes)))
+		ms = append(ms, metrics.CacheMultihashes.M(int64(st.Indexes)))
 	}
 	if st.Values != e.prevCacheStats.Values {
 		ms = append(ms, metrics.CacheValues.M(int64(st.Values)))

--- a/go.mod
+++ b/go.mod
@@ -12,4 +12,5 @@ require (
 	github.com/libp2p/go-libp2p-core v0.9.0
 	github.com/multiformats/go-multihash v0.0.16
 	go.opencensus.io v0.23.0
+	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871
 )

--- a/go.sum
+++ b/go.sum
@@ -327,8 +327,9 @@ golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
-golang.org/x/crypto v0.0.0-20210506145944-38f3c27a63bf h1:B2n+Zi5QeYRDAEodEu72OS36gmTWjgpXr2+cWcBW90o=
 golang.org/x/crypto v0.0.0-20210506145944-38f3c27a63bf/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
+golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 h1:/pEO3GD/ABYAjuakUS6xSEmmlyVS4kxBNkeA9tLJiTI=
+golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
@@ -349,6 +350,7 @@ golang.org/x/net v0.0.0-20190611141213-3f473d35a33a/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -368,13 +370,16 @@ golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210309074719-68d13333faf2 h1:46ULzRKLh1CwgRq2dC5SlBzEqqNCi8rreOZnNrbqcIY=
 golang.org/x/sys v0.0.0-20210309074719-68d13333faf2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -15,15 +15,16 @@ var (
 
 // Measures
 var (
-	CacheHits      = stats.Int64("core/cache/hits", "Number of retireval cache hits", stats.UnitDimensionless)
-	CacheMisses    = stats.Int64("core/cache/misses", "Number of retireval cache misses", stats.UnitDimensionless)
-	CacheItems     = stats.Int64("core/cache/items", "Number of indexes in cache", stats.UnitDimensionless)
-	CacheValues    = stats.Int64("core/cache/values", "Number of values in cache", stats.UnitDimensionless)
-	CacheEvictions = stats.Int64("core/cache/evictions", "Number of indexes evicted from cache", stats.UnitDimensionless)
-	CacheMisuse    = stats.Int64("core/cache/misuse", "Cache clears due to high value to multihash ratio (indexer misuse)", stats.UnitDimensionless)
+	CacheHits        = stats.Int64("core/cache/hits", "Number of retireval cache hits", stats.UnitDimensionless)
+	CacheMisses      = stats.Int64("core/cache/misses", "Number of retireval cache misses", stats.UnitDimensionless)
+	CacheMultihashes = stats.Int64("core/cache/items", "Number of cached multihashes", stats.UnitDimensionless)
+	CacheValues      = stats.Int64("core/cache/values", "Number of cached values", stats.UnitDimensionless)
+	CacheEvictions   = stats.Int64("core/cache/evictions", "Number of indexes evicted from cache", stats.UnitDimensionless)
+	CacheMisuse      = stats.Int64("core/cache/misuse", "Cache clears due to high value to multihash ratio (indexer misuse)", stats.UnitDimensionless)
 
 	GetIndexLatency   = stats.Float64("core/get_index_latency", "Time to retrieve an index", stats.UnitMilliseconds)
 	IngestMultihashes = stats.Int64("core/ingest_multihashes", "Number of multihashes put into the indexer", stats.UnitDimensionless)
+	RemovedProviders  = stats.Int64("core/removed_providers", "Number of providers removed from indexer", stats.UnitDimensionless)
 	StoreSize         = stats.Int64("core/storage_size", "Bytes of storage used to store the indexed content", stats.UnitBytes)
 )
 
@@ -37,8 +38,8 @@ var (
 		Measure:     CacheMisses,
 		Aggregation: view.Count(),
 	}
-	cacheItemsView = &view.View{
-		Measure:     CacheItems,
+	cacheMultihashesView = &view.View{
+		Measure:     CacheMultihashes,
 		Aggregation: view.LastValue(),
 	}
 	cacheValuesView = &view.View{
@@ -62,6 +63,10 @@ var (
 		Measure:     IngestMultihashes,
 		Aggregation: view.Sum(),
 	}
+	removedProvidersView = &view.View{
+		Measure:     RemovedProviders,
+		Aggregation: view.Sum(),
+	}
 
 	storeSizeView = &view.View{
 		Measure:     StoreSize,
@@ -73,12 +78,13 @@ var (
 var DefaultViews = []*view.View{
 	cacheHitsView,
 	cacheMissesView,
-	cacheItemsView,
+	cacheMultihashesView,
 	cacheValuesView,
 	cacheEvictionsView,
 	cacheMisuseView,
 	getIndexLatencyView,
 	ingestMultihashesView,
+	removedProvidersView,
 	storeSizeView,
 }
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -17,7 +17,7 @@ var (
 var (
 	CacheHits        = stats.Int64("core/cache/hits", "Number of retireval cache hits", stats.UnitDimensionless)
 	CacheMisses      = stats.Int64("core/cache/misses", "Number of retireval cache misses", stats.UnitDimensionless)
-	CacheMultihashes = stats.Int64("core/cache/items", "Number of cached multihashes", stats.UnitDimensionless)
+	CacheMultihashes = stats.Int64("core/cache/multihashes", "Number of cached multihashes", stats.UnitDimensionless)
 	CacheValues      = stats.Int64("core/cache/values", "Number of cached values", stats.UnitDimensionless)
 	CacheEvictions   = stats.Int64("core/cache/evictions", "Number of indexes evicted from cache", stats.UnitDimensionless)
 	CacheMisuse      = stats.Int64("core/cache/misuse", "Cache clears due to high value to multihash ratio (indexer misuse)", stats.UnitDimensionless)

--- a/store/pogreb/pogreb.go
+++ b/store/pogreb/pogreb.go
@@ -26,6 +26,10 @@ import (
 
 const DefaultSyncInterval = time.Second
 
+// valueKeySize is the number of bytes of hash(providerID + contextID) used as
+// key to lookup values.
+const valueKeySize = 20
+
 var (
 	indexKeyPrefix = []byte("idx")
 	valueKeyPrefix = []byte("md")
@@ -445,7 +449,7 @@ func makeValueKey(value indexer.Value) []byte {
 	// Create a hash of the ProviderID and ContextID so that the key length is
 	// fixed.  This hash is used to look up the Value, which contains
 	// ProviderID, ContextID, and Metadata.
-	h, err := blake2b.New256(nil)
+	h, err := blake2b.New(valueKeySize, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/store/pogreb/pogreb.go
+++ b/store/pogreb/pogreb.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"crypto/sha1"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -27,14 +28,14 @@ const DefaultSyncInterval = time.Second
 
 var (
 	indexKeyPrefix = []byte("idx")
-	mdKeyPrefix    = []byte("md")
+	valueKeyPrefix = []byte("md")
 )
 
 type pStorage struct {
-	dir    string
-	store  *pogreb.DB
-	mlk    *keymutex.KeyMutex
-	mdLock sync.RWMutex
+	dir     string
+	store   *pogreb.DB
+	mlk     *keymutex.KeyMutex
+	valLock sync.RWMutex
 }
 
 type pogrebIter struct {
@@ -63,13 +64,13 @@ func (s *pStorage) Get(m multihash.Multihash) ([]indexer.Value, bool, error) {
 }
 
 func (s *pStorage) Put(value indexer.Value, mhs ...multihash.Multihash) error {
-	err := s.updateMetadata(value, len(mhs) != 0)
+	valKey, err := s.updateValue(value, len(mhs) != 0)
 	if err != nil {
-		return err
+		return fmt.Errorf("cannot update stored value: %w", err)
 	}
 
 	for i := range mhs {
-		err = s.putIndex(mhs[i], value)
+		err = s.putIndex(mhs[i], valKey)
 		if err != nil {
 			return err
 		}
@@ -94,13 +95,11 @@ func (s *pStorage) RemoveProvider(providerID peer.ID) error {
 	}
 	iter := s.store.Items()
 
-	valsToDel := map[string]struct{}{}
-
-	s.mdLock.Lock()
-	defer s.mdLock.Unlock()
+	s.valLock.Lock()
+	defer s.valLock.Unlock()
 
 	for {
-		key, val, err := iter.Next()
+		key, valueData, err := iter.Next()
 		if err != nil {
 			if err == pogreb.ErrIterationDone {
 				break
@@ -108,87 +107,38 @@ func (s *pStorage) RemoveProvider(providerID peer.ID) error {
 			return err
 		}
 
-		if !bytes.HasPrefix(key, indexKeyPrefix) {
-			// Key does not have index prefix, so is not an index key.
+		if !bytes.HasPrefix(key, valueKeyPrefix) {
+			// Key does not have value prefix, so is not an value key.
 			continue
 		}
 
-		values, err := indexer.UnmarshalValues(val)
-		if err != nil {
-			return err
-		}
-
-		if len(values) == 0 {
-			if err = s.store.Delete(key); err != nil {
-				return err
-			}
-			continue
-		}
-
-		// Separate values into those to remove and those to keep.
-		var vdel, vkeep []indexer.Value
-		for i := range values {
-			if values[i].ProviderID == providerID {
-				vdel = append(vdel, values[i])
-			} else {
-				vkeep = append(vkeep, values[i])
-			}
-		}
-
-		if len(vdel) == 0 {
-			continue
-		}
-
-		// If there are no values to keep, then remove the index.  Otherwise,
-		// update the index to have the remaining values.
-		if len(vkeep) == 0 {
-			if err = s.store.Delete(key); err != nil {
-				return err
-			}
-		} else {
-			// store the list of value keys for the multihash
-			b, err := indexer.MarshalValues(vkeep)
+		if valueData != nil {
+			value, err := indexer.UnmarshalValue(valueData)
 			if err != nil {
 				return err
 			}
-			err = s.store.Put(key, b)
-			if err != nil {
-				return err
+
+			if value.ProviderID != providerID {
+				continue
 			}
 		}
 
-		for i := range vdel {
-			valsToDel[string(vdel[i].ContextID)] = struct{}{}
-		}
-	}
-
-	// Delete the metadata for each value.
-	var buf bytes.Buffer
-	for ctxid := range valsToDel {
-		buf.WriteString(ctxid)
-		mdKey := makeMetadataKey(indexer.Value{
-			ProviderID: providerID,
-			ContextID:  buf.Bytes(),
-		})
-		// Remove metadata.
-		err = s.store.Delete(mdKey)
-		if err != nil {
+		if err = s.store.Delete(key); err != nil {
 			return err
 		}
-		buf.Reset()
 	}
 
 	return nil
 }
 
 func (s *pStorage) RemoveProviderContext(providerID peer.ID, contextID []byte) error {
-	mdKey := makeMetadataKey(indexer.Value{
+	mdKey := makeValueKey(indexer.Value{
 		ProviderID: providerID,
 		ContextID:  contextID,
 	})
 
-	s.mdLock.Lock()
-	defer s.mdLock.Unlock()
+	s.valLock.Lock()
+	defer s.valLock.Unlock()
 
 	// Remove any previous value.
 	return s.store.Delete(mdKey)
@@ -229,7 +179,7 @@ func (s *pStorage) Iter() (indexer.Iterator, error) {
 
 func (it *pogrebIter) Next() (multihash.Multihash, []indexer.Value, error) {
 	for {
-		key, val, err := it.iter.Next()
+		key, valKeysData, err := it.iter.Next()
 		if err != nil {
 			if err == pogreb.ErrIterationDone {
 				err = io.EOF
@@ -237,42 +187,51 @@ func (it *pogrebIter) Next() (multihash.Multihash, []indexer.Value, error) {
 			return nil, nil, err
 		}
 
-		if bytes.HasPrefix(key, indexKeyPrefix) {
-			values, err := indexer.UnmarshalValues(val)
-			if err != nil {
-				return nil, nil, err
-			}
-
-			// Get the metadata for each value
-			values, err = it.s.populateMetadata(key, values)
-			if err != nil {
-				return nil, nil, err
-			}
-			if len(values) == 0 {
-				continue
-			}
-
-			return multihash.Multihash(key[len(indexKeyPrefix):]), values, nil
+		if !bytes.HasPrefix(key, indexKeyPrefix) {
+			continue
 		}
+
+		valueKeys, err := indexer.UnmarshalValueKeys(valKeysData)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// Get the value for each value key
+		values, err := it.s.getValues(key, valueKeys)
+		if err != nil {
+			return nil, nil, err
+		}
+		if len(values) == 0 {
+			continue
+		}
+
+		return multihash.Multihash(key[len(indexKeyPrefix):]), values, nil
 	}
 }
 
+func (s *pStorage) getValueKeys(k []byte) ([][]byte, error) {
+	valueKeysData, err := s.store.Get(k)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot get multihash from store: %w", err)
+	}
+	if valueKeysData == nil {
+		return nil, nil
+	}
+
+	return indexer.UnmarshalValueKeys(valueKeysData)
+}
+
 func (s *pStorage) get(k []byte) ([]indexer.Value, bool, error) {
-	valueData, err := s.store.Get(k)
+	valueKeys, err := s.getValueKeys(k)
 	if err != nil {
 		return nil, false, err
 	}
-	if valueData == nil {
+	if valueKeys == nil {
 		return nil, false, nil
 	}
 
-	values, err := indexer.UnmarshalValues(valueData)
-	if err != nil {
-		return nil, false, err
-	}
-
-	// Get the metadata for each value
-	values, err = s.populateMetadata(k, values)
+	// Get the value for each value key.
+	values, err := s.getValues(k, valueKeys)
 	if err != nil {
 		return nil, false, err
 	}
@@ -284,40 +243,36 @@ func (s *pStorage) get(k []byte) ([]indexer.Value, bool, error) {
 	return values, true, nil
 }
 
-func (s *pStorage) putIndex(m multihash.Multihash, value indexer.Value) error {
+func (s *pStorage) putIndex(m multihash.Multihash, valKey []byte) error {
 	k := makeIndexKey(m)
 
 	s.lock(k)
 	defer s.unlock(k)
 
-	existing, found, err := s.get(k)
+	existingValKeys, err := s.getValueKeys(k)
 	if err != nil {
 		return err
 	}
-	if found {
-		// If found it means there is already a value there.  Check if we are
-		// trying to put a duplicate value.
-		for j := range existing {
-			if value.Match(existing[j]) {
-				return nil
-			}
+	// If found it means there is already a value there.  Check if we are
+	// trying to put a duplicate value.
+	for _, existing := range existingValKeys {
+		if bytes.Equal(valKey, existing) {
+			return nil
 		}
 	}
 
-	// Values are stored without metadata, and are used as a key to lookup
-	// the metadata.
-	value.MetadataBytes = nil
-	vals := append(existing, value)
+	valKeys := append(existingValKeys, valKey)
 
 	// Store the list of value keys for the multihash.
-	b, err := indexer.MarshalValues(vals)
+	b, err := indexer.MarshalValueKeys(valKeys)
 	if err != nil {
-		return err
+		return fmt.Errorf("cannot encode value keys for index: %w", err)
 	}
 
 	err = s.store.Put(k, b)
 	if err != nil {
-		return err
+		return fmt.Errorf("cannot put multihash: %w", err)
+
 	}
 
 	return nil
@@ -329,76 +284,76 @@ func (s *pStorage) removeIndex(m multihash.Multihash, value indexer.Value) error
 	s.lock(k)
 	defer s.unlock(k)
 
-	old, found, err := s.get(k)
+	valueKeys, err := s.getValueKeys(k)
 	if err != nil {
 		return err
 	}
-	// If found it means there is a value for the multihash.  Check if there is
-	// something to remove.
-	if !found {
-		return nil
-	}
 
-	return s.removeValue(k, value, old)
-}
+	valKey := makeValueKey(value)
 
-func (s *pStorage) updateMetadata(value indexer.Value, saveNew bool) error {
-	// All values must have metadata, even if this only consists of the
-	// protocol ID.  When retrieving values, those that have nil metadata are
-	// ones that have been deleted, and this is used to remove remaining
-	// mappings from a multihash to the value.
-	if len(value.MetadataBytes) == 0 {
-		return errors.New("value missing metadata")
-	}
-
-	mdKey := makeMetadataKey(value)
-
-	s.mdLock.Lock()
-	defer s.mdLock.Unlock()
-
-	// See if there is a previous value.
-	metadata, err := s.store.Get(mdKey)
-	if err != nil {
-		return err
-	}
-	if metadata == nil {
-		if saveNew {
-			// Store the new metadata
-			return s.store.Put(mdKey, value.MetadataBytes)
-		}
-		return nil
-	}
-
-	// Found previous metadata.  If it is different, then update it.
-	if !bytes.Equal(value.MetadataBytes, metadata) {
-		return s.store.Put(mdKey, value.MetadataBytes)
-	}
-
-	return nil
-}
-
-func (s *pStorage) removeValue(k []byte, value indexer.Value, stored []indexer.Value) error {
-	for i := range stored {
-		if value.Match(stored[i]) {
-			// If it is the only value, remove the value.
-			if len(stored) == 1 {
+	for i := range valueKeys {
+		if bytes.Equal(valKey, valueKeys[i]) {
+			if len(valueKeys) == 1 {
 				return s.store.Delete(k)
 			}
-
-			// Remove from value and put updated structure.
-			stored[i] = stored[len(stored)-1]
-			stored[len(stored)-1] = indexer.Value{}
-			b, err := indexer.MarshalValues(stored[:len(stored)-1])
+			valueKeys[i] = valueKeys[len(valueKeys)-1]
+			valueKeys[len(valueKeys)-1] = nil
+			valueKeys = valueKeys[:len(valueKeys)-1]
+			b, err := indexer.MarshalValueKeys(valueKeys)
 			if err != nil {
 				return err
 			}
-			if err := s.store.Put(k, b); err != nil {
-				return err
-			}
-			return nil
+			return s.store.Put(k, b)
 		}
 	}
 	return nil
+}
+
+func (s *pStorage) updateValue(value indexer.Value, saveNew bool) ([]byte, error) {
+	// All values must have metadata, even if this only consists of the
+	// protocol ID.
+	if len(value.MetadataBytes) == 0 {
+		return nil, errors.New("value missing metadata")
+	}
+
+	valKey := makeValueKey(value)
+
+	s.valLock.Lock()
+	defer s.valLock.Unlock()
+
+	// See if there is a previous value.
+	valData, err := s.store.Get(valKey)
+	if err != nil {
+		return nil, err
+	}
+	if valData == nil {
+		if saveNew {
+			// Store the new value.
+			valData, err := indexer.MarshalValue(value)
+			if err != nil {
+				return nil, err
+			}
+			err = s.store.Put(valKey, valData)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return valKey, nil
+	}
+
+	// Found previous value.  If it is different, then update it.
+	newValData, err := indexer.MarshalValue(value)
+	if err != nil {
+		return nil, err
+	}
+	if !bytes.Equal(newValData, valData) {
+		err = s.store.Put(valKey, newValData)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return valKey, nil
 }
 
 func (s *pStorage) lock(k []byte) {
@@ -409,55 +364,48 @@ func (s *pStorage) unlock(k []byte) {
 	s.mlk.UnlockBytes(k)
 }
 
-func (s *pStorage) populateMetadata(key []byte, values []indexer.Value) ([]indexer.Value, error) {
-	s.mdLock.RLock()
-	defer s.mdLock.RUnlock()
+func (s *pStorage) getValues(key []byte, valueKeys [][]byte) ([]indexer.Value, error) {
+	startLen := len(valueKeys)
+	var values []indexer.Value
 
-	startLen := len(values)
-	for i := 0; i < len(values); {
-		// Try to get metadata from previous matching value.
-		var prev int
-		for prev = i - 1; prev >= 0; prev-- {
-			if values[i].Match(values[prev]) {
-				values[i].MetadataBytes = values[prev].MetadataBytes
-				break
-			}
+	s.valLock.RLock()
+	for i := 0; i < len(valueKeys); {
+		// Fetch value from datastore
+		valData, err := s.store.Get(valueKeys[i])
+		if err != nil {
+			s.valLock.RUnlock()
+			return nil, err
 		}
-		// If metadata not in previous value, fetch from datastore.
-		if prev < 0 {
-			md, err := s.store.Get(makeMetadataKey(values[i]))
-			if err != nil {
-				return nil, err
-			}
-			if md == nil {
-				// If metadata not in datastore, this means it has been
-				// deleted, and the mapping from the multihash to that value
-				// should also be removed.
-				values[i] = values[len(values)-1]
-				values[len(values)-1] = indexer.Value{}
-				values = values[:len(values)-1]
-				continue
-			}
-			values[i].MetadataBytes = md
+		if valData == nil {
+			// If value not in datastore, this means it has been
+			// deleted, and the mapping from the multihash to that value
+			// should also be removed.
+			valueKeys[i] = valueKeys[len(valueKeys)-1]
+			valueKeys[len(valueKeys)-1] = nil
+			valueKeys = valueKeys[:len(valueKeys)-1]
+			continue
 		}
+		val, err := indexer.UnmarshalValue(valData)
+		if err != nil {
+			s.valLock.RUnlock()
+			return nil, err
+		}
+		values = append(values, val)
 		i++
 	}
-	if len(values) < startLen {
+	s.valLock.RUnlock()
+
+	if len(valueKeys) < startLen {
 		s.lock(key)
 		defer s.unlock(key)
 
-		if len(values) == 0 {
+		if len(valueKeys) == 0 {
 			err := s.store.Delete(key)
 			return nil, err
 		}
 
-		// Update the values this metadata maps to.
-		storeVals := make([]indexer.Value, len(values))
-		for i := range values {
-			storeVals[i] = values[i]
-			storeVals[i].MetadataBytes = nil
-		}
-		b, err := indexer.MarshalValues(storeVals)
+		// Update the values this multihash maps to.
+		b, err := indexer.MarshalValueKeys(valueKeys)
 		if err != nil {
 			return nil, err
 		}
@@ -478,7 +426,7 @@ func makeIndexKey(m multihash.Multihash) []byte {
 	return b.Bytes()
 }
 
-func makeMetadataKey(value indexer.Value) []byte {
+func makeValueKey(value indexer.Value) []byte {
 	// Create a sha1 hash of the ProviderID and ContextID so that the key
 	// length is fixed.  Note: a faster non-crypto hash could be used here.
 	h := sha1.New()
@@ -486,8 +434,8 @@ func makeMetadataKey(value indexer.Value) []byte {
 	h.Write(value.ContextID)
 
 	var b bytes.Buffer
-	b.Grow(len(mdKeyPrefix) + sha1.Size)
-	b.Write(mdKeyPrefix)
+	b.Grow(len(valueKeyPrefix) + sha1.Size)
+	b.Write(valueKeyPrefix)
 	b.Write(h.Sum(nil))
 	return b.Bytes()
 }

--- a/store/pogreb/pogreb_test.go
+++ b/store/pogreb/pogreb_test.go
@@ -70,6 +70,20 @@ func TestRemoveProvider(t *testing.T) {
 	test.RemoveProviderTest(t, s)
 }
 
+func TestClose(t *testing.T) {
+	skipIf32bit(t)
+
+	s := initPogreb(t)
+	err := s.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = s.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func skipIf32bit(t *testing.T) {
 	if runtime.GOARCH == "386" {
 		t.Skip("Pogreb cannot use GOARCH=386")

--- a/store/storethehash/storethehash.go
+++ b/store/storethehash/storethehash.go
@@ -22,14 +22,14 @@ import (
 
 var (
 	indexKeySuffix = []byte("I")
-	mdKeySuffix    = []byte("M")
+	valueKeySuffix = []byte("M")
 )
 
 type sthStorage struct {
-	dir    string
-	store  *sth.Store
-	mlk    *keymutex.KeyMutex
-	mdLock sync.RWMutex
+	dir     string
+	store   *sth.Store
+	mlk     *keymutex.KeyMutex
+	valLock sync.RWMutex
 
 	primary *mhprimary.MultihashPrimary
 }
@@ -79,13 +79,13 @@ func (s *sthStorage) Get(m multihash.Multihash) ([]indexer.Value, bool, error) {
 }
 
 func (s *sthStorage) Put(value indexer.Value, mhs ...multihash.Multihash) error {
-	err := s.updateMetadata(value, len(mhs) != 0)
+	valKey, err := s.updateValue(value, len(mhs) != 0)
 	if err != nil {
-		return fmt.Errorf("cannot update metadata: %w", err)
+		return fmt.Errorf("cannot update stored value: %w", err)
 	}
 
 	for i := range mhs {
-		err = s.putIndex(mhs[i], value)
+		err = s.putIndex(mhs[i], valKey)
 		if err != nil {
 			return err
 		}
@@ -95,8 +95,7 @@ func (s *sthStorage) Put(value indexer.Value, mhs ...multihash.Multihash) error 
 
 func (s *sthStorage) Remove(value indexer.Value, mhs ...multihash.Multihash) error {
 	for i := range mhs {
-		k := makeIndexKey(mhs[i])
-		err := s.removeIndex(k, value)
+		err := s.removeIndex(mhs[i], value)
 		if err != nil {
 			return err
 		}
@@ -111,11 +110,8 @@ func (s *sthStorage) RemoveProvider(providerID peer.ID) error {
 		return err
 	}
 
-	uniqKeys := map[string]struct{}{}
-	valsToDel := map[string]struct{}{}
-
-	s.mdLock.Lock()
-	defer s.mdLock.Unlock()
+	s.valLock.Lock()
+	defer s.valLock.Unlock()
 
 	for {
 		key, _, err := iter.Next()
@@ -131,102 +127,47 @@ func (s *sthStorage) RemoveProvider(providerID peer.ID) error {
 		if err != nil {
 			return err
 		}
-		if !bytes.HasSuffix(dm.Digest, indexKeySuffix) {
-			// Key does not have index prefix, so is not an index key.
+		if !bytes.HasSuffix(dm.Digest, valueKeySuffix) {
+			// Key does not have value suffix, so is not an value key.
 			continue
 		}
-
-		mhb := make([]byte, len(dm.Digest)-len(indexKeySuffix))
-		copy(mhb, dm.Digest)
-		reverseBytes(mhb)
-		origMultihash := multihash.Multihash(mhb)
-		k := string(origMultihash)
-		_, found := uniqKeys[k]
-		if found {
-			continue
-		}
-		uniqKeys[k] = struct{}{}
 
 		valueData, found, err := s.store.Get(multihash.Multihash(key))
 		if err != nil {
 			return err
 		}
-		if !found {
-			continue
+
+		if found {
+			value, err := indexer.UnmarshalValue(valueData)
+			if err != nil {
+				return err
+			}
+
+			if value.ProviderID != providerID {
+				continue
+			}
 		}
-		values, err := indexer.UnmarshalValues(valueData)
+
+		_, err = s.store.Remove(key)
 		if err != nil {
 			return err
 		}
-
-		// Separate values into those to remove and those to keep.
-		var vdel, vkeep []indexer.Value
-		for i := range values {
-			if values[i].ProviderID == providerID {
-				vdel = append(vdel, values[i])
-			} else {
-				vkeep = append(vkeep, values[i])
-			}
-		}
-
-		if len(vdel) == 0 {
-			continue
-		}
-
-		// If there are no values to keep, then remove the index.  Otherwise,
-		// update the index to have the remaining values.
-		if len(vkeep) == 0 {
-			_, err = s.store.Remove(key)
-			if err != nil {
-				return err
-			}
-		} else {
-			// store the list of value keys for the multihash
-			b, err := indexer.MarshalValues(vkeep)
-			if err != nil {
-				return err
-			}
-			err = s.store.Put(key, b)
-			if err != nil {
-				return err
-			}
-		}
-
-		for i := range vdel {
-			valsToDel[string(vdel[i].ContextID)] = struct{}{}
-		}
-	}
-
-	// Delete the metadata for each value.
-	var buf bytes.Buffer
-	for ctxid := range valsToDel {
-		buf.WriteString(ctxid)
-		mdKey := makeMetadataKey(indexer.Value{
-			ProviderID: providerID,
-			ContextID:  buf.Bytes(),
-		})
-		// Remove metadata.
-		_, err = s.store.Remove(mdKey)
-		if err != nil {
-			return err
-		}
-		buf.Reset()
 	}
 
 	return nil
 }
 
 func (s *sthStorage) RemoveProviderContext(providerID peer.ID, contextID []byte) error {
-	mdKey := makeMetadataKey(indexer.Value{
+	valKey := makeValueKey(indexer.Value{
 		ProviderID: providerID,
 		ContextID:  contextID,
 	})
 
-	s.mdLock.Lock()
-	defer s.mdLock.Unlock()
+	s.valLock.Lock()
+	defer s.valLock.Unlock()
 
 	// Remove any previous value.
-	_, err := s.store.Remove(mdKey)
+	_, err := s.store.Remove(valKey)
 	return err
 }
 
@@ -304,20 +245,21 @@ func (it *sthIterator) Next() (multihash.Multihash, []indexer.Value, error) {
 		}
 		it.uniqKeys[k] = struct{}{}
 
-		valueData, found, err := it.storage.store.Get(multihash.Multihash(key))
+		valueKeysData, found, err := it.storage.store.Get(multihash.Multihash(key))
 		if err != nil {
 			return nil, nil, err
 		}
 		if !found {
 			continue
 		}
-		values, err := indexer.UnmarshalValues(valueData)
+
+		valueKeys, err := indexer.UnmarshalValueKeys(valueKeysData)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		// Get the metadata for each value
-		values, err = it.storage.populateMetadata(key, values)
+		// Get the value for each value key
+		values, err := it.storage.getValues(key, valueKeys)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -330,22 +272,29 @@ func (it *sthIterator) Next() (multihash.Multihash, []indexer.Value, error) {
 	}
 }
 
+func (s *sthStorage) getValueKeys(k []byte) ([][]byte, error) {
+	valueKeysData, found, err := s.store.Get(k)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot get multihash from store: %w", err)
+	}
+	if !found {
+		return nil, nil
+	}
+
+	return indexer.UnmarshalValueKeys(valueKeysData)
+}
+
 func (s *sthStorage) get(k []byte) ([]indexer.Value, bool, error) {
-	value, found, err := s.store.Get(k)
+	valueKeys, err := s.getValueKeys(k)
 	if err != nil {
 		return nil, false, err
 	}
-	if !found {
+	if valueKeys == nil {
 		return nil, false, nil
 	}
 
-	values, err := indexer.UnmarshalValues(value)
-	if err != nil {
-		return nil, false, err
-	}
-
-	// Get the metadata for each value
-	values, err = s.populateMetadata(k, values)
+	// Get the value for each value key.
+	values, err := s.getValues(k, valueKeys)
 	if err != nil {
 		return nil, false, err
 	}
@@ -357,121 +306,113 @@ func (s *sthStorage) get(k []byte) ([]indexer.Value, bool, error) {
 	return values, true, nil
 }
 
-func (s *sthStorage) putIndex(m multihash.Multihash, value indexer.Value) error {
+func (s *sthStorage) putIndex(m multihash.Multihash, valKey []byte) error {
 	k := makeIndexKey(m)
 
 	s.lock(k)
 	defer s.unlock(k)
 
-	// NOTE: The implementation of Put in storethehash already performs a first
-	// lookup to check the type of update that needs to be done over the
-	// key. We can probably save this additional get access by implementing a
-	// duplicate value comparison low-level
-	existing, found, err := s.get(k)
+	existingValKeys, err := s.getValueKeys(k)
 	if err != nil {
 		return err
 	}
-	if found {
-		// If found it means there is already a value there.  Check if we are
-		// trying to put a duplicate value.
-		for j := range existing {
-			if value.Match(existing[j]) {
-				return nil
-			}
+	// If found it means there is already a value there.  Check if we are
+	// trying to put a duplicate value.
+	for _, existing := range existingValKeys {
+		if bytes.Equal(valKey, existing) {
+			return nil
 		}
 	}
 
-	// Values are stored without metadata, and are used as a key to lookup the
-	// metadata.
-	value.MetadataBytes = nil
-	vals := append(existing, value)
+	valKeys := append(existingValKeys, valKey)
 
-	// store the list of value keys for the multihash
-	b, err := indexer.MarshalValues(vals)
+	// Store the new list of value keys for the multihash
+	b, err := indexer.MarshalValueKeys(valKeys)
 	if err != nil {
-		return err
+		return fmt.Errorf("cannot encode value keys for index: %w", err)
 	}
 
 	err = s.store.Put(k, b)
 	if err != nil {
-		return err
+		return fmt.Errorf("cannot put multihash: %w", err)
 	}
 
 	return nil
 }
 
-func (s *sthStorage) updateMetadata(value indexer.Value, saveNew bool) error {
+func (s *sthStorage) updateValue(value indexer.Value, saveNew bool) ([]byte, error) {
 	// All values must have metadata, even if this only consists of the
-	// protocol ID.  When retrieving values, those that have nil metadata are
-	// ones that have been deleted, and this is used to remove remaining
-	// mappings from a multihash to the value.
+	// protocol ID.
 	if len(value.MetadataBytes) == 0 {
-		return errors.New("value missing metadata")
+		return nil, errors.New("value missing metadata")
 	}
 
-	mdKey := makeMetadataKey(value)
+	valKey := makeValueKey(value)
 
-	s.mdLock.Lock()
-	defer s.mdLock.Unlock()
+	s.valLock.Lock()
+	defer s.valLock.Unlock()
 
 	// See if there is a previous value.
-	metadata, found, err := s.store.Get(mdKey)
+	valData, found, err := s.store.Get(valKey)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if !found {
 		if saveNew {
-			// Store the new metadata
-			return s.store.Put(mdKey, value.MetadataBytes)
+			// Store the new value.
+			valData, err := indexer.MarshalValue(value)
+			if err != nil {
+				return nil, err
+			}
+			err = s.store.Put(valKey, valData)
+			if err != nil {
+				return nil, err
+			}
 		}
-		return nil
+		return valKey, nil
 	}
 
-	// Found previous metadata.  If it is different, then update it.
-	if !bytes.Equal(value.MetadataBytes, metadata) {
-		return s.store.Put(mdKey, value.MetadataBytes)
+	// Found previous value.  If it is different, then update it.
+	newValData, err := indexer.MarshalValue(value)
+	if err != nil {
+		return nil, err
+	}
+	if !bytes.Equal(newValData, valData) {
+		if err = s.store.Put(valKey, newValData); err != nil {
+			return nil, err
+		}
 	}
 
-	return nil
+	return valKey, nil
 }
 
-func (s *sthStorage) removeIndex(k []byte, value indexer.Value) error {
+func (s *sthStorage) removeIndex(m multihash.Multihash, value indexer.Value) error {
+	k := makeIndexKey(m)
+
 	s.lock(k)
 	defer s.unlock(k)
 
-	old, found, err := s.get(k)
+	valueKeys, err := s.getValueKeys(k)
 	if err != nil {
 		return err
 	}
-	// If found it means there is a value for the multihash check if there is
-	// something to remove.
-	if !found {
-		return nil
-	}
 
-	return s.removeValue(k, value, old)
-}
+	valKey := makeValueKey(value)
 
-func (s *sthStorage) removeValue(k []byte, value indexer.Value, stored []indexer.Value) error {
-	for i := range stored {
-		if value.Match(stored[i]) {
-			// It is the only value, remove the value
-			if len(stored) == 1 {
-				_, err := s.store.Remove(k)
+	for i := range valueKeys {
+		if bytes.Equal(valKey, valueKeys[i]) {
+			if len(valueKeys) == 1 {
+				_, err = s.store.Remove(k)
 				return err
 			}
-
-			// else remove from value and put updated structure
-			stored[i] = stored[len(stored)-1]
-			stored[len(stored)-1] = indexer.Value{}
-			b, err := indexer.MarshalValues(stored[:len(stored)-1])
+			valueKeys[i] = valueKeys[len(valueKeys)-1]
+			valueKeys[len(valueKeys)-1] = nil
+			valueKeys = valueKeys[:len(valueKeys)-1]
+			b, err := indexer.MarshalValueKeys(valueKeys)
 			if err != nil {
 				return err
 			}
-			if err := s.store.Put(k, b); err != nil {
-				return err
-			}
-			return nil
+			return s.store.Put(k, b)
 		}
 	}
 	return nil
@@ -485,59 +426,48 @@ func (s *sthStorage) unlock(k []byte) {
 	s.mlk.UnlockBytes(k)
 }
 
-func (s *sthStorage) populateMetadata(key []byte, values []indexer.Value) ([]indexer.Value, error) {
-	s.mdLock.RLock()
-	defer s.mdLock.RUnlock()
+func (s *sthStorage) getValues(key []byte, valueKeys [][]byte) ([]indexer.Value, error) {
+	startLen := len(valueKeys)
+	var values []indexer.Value
 
-	startLen := len(values)
-	for i := 0; i < len(values); {
-		// Try to get metadata from previous matching value.
-		var prev int
-		for prev = i - 1; prev >= 0; prev-- {
-			prevVal := values[prev]
-			if values[i].Match(prevVal) {
-				values[i].MetadataBytes = prevVal.MetadataBytes
-				break
-			}
+	s.valLock.RLock()
+	for i := 0; i < len(valueKeys); {
+		// Fetch value from datastore.
+		valData, found, err := s.store.Get(valueKeys[i])
+		if err != nil {
+			s.valLock.RUnlock()
+			return nil, err
 		}
-		// If metadata not in previous value, fetch from datastore.
-		if prev < 0 {
-			md, found, err := s.store.Get(makeMetadataKey(values[i]))
-			if err != nil {
-				return nil, err
-			}
-			if !found {
-				// If metadata not in datastore, this means it has been
-				// deleted, and the mapping from the multihash to that value
-				// should also be removed.
-				values[i] = values[len(values)-1]
-				values[len(values)-1] = indexer.Value{}
-				values = values[:len(values)-1]
-				continue
-			}
-			values[i].MetadataBytes = md
+		if !found {
+			// If value not in datastore, this means it has been
+			// deleted, and the mapping from the multihash to that value
+			// should also be removed.
+			valueKeys[i] = valueKeys[len(valueKeys)-1]
+			valueKeys[len(valueKeys)-1] = nil
+			valueKeys = valueKeys[:len(valueKeys)-1]
+			continue
 		}
+		val, err := indexer.UnmarshalValue(valData)
+		if err != nil {
+			s.valLock.RUnlock()
+			return nil, err
+		}
+		values = append(values, val)
 		i++
 	}
-	if len(values) < startLen {
+	s.valLock.RUnlock()
+
+	if len(valueKeys) < startLen {
 		s.lock(key)
 		defer s.unlock(key)
 
-		if len(values) == 0 {
+		if len(valueKeys) == 0 {
 			_, err := s.store.Remove(key)
-			if err != nil {
-				return nil, err
-			}
-			return nil, nil
+			return nil, err
 		}
 
-		// Update the values this metadata maps to.
-		storeVals := make([]indexer.Value, len(values))
-		for i := range values {
-			storeVals[i] = values[i]
-			storeVals[i].MetadataBytes = nil
-		}
-		b, err := indexer.MarshalValues(storeVals)
+		// Update the values this mmultihash maps to.
+		b, err := indexer.MarshalValueKeys(valueKeys)
 		if err != nil {
 			return nil, err
 		}
@@ -573,7 +503,7 @@ func reverseBytes(b []byte) {
 	}
 }
 
-func makeMetadataKey(value indexer.Value) multihash.Multihash {
+func makeValueKey(value indexer.Value) multihash.Multihash {
 	// Create a sha1 hash of the ProviderID and ContextID so that the key
 	// length is fixed.  Note: a faster non-crypto hash could be used here.
 	h := sha1.New()
@@ -581,9 +511,9 @@ func makeMetadataKey(value indexer.Value) multihash.Multihash {
 	h.Write(value.ContextID)
 
 	var b bytes.Buffer
-	b.Grow(sha1.Size + len(mdKeySuffix))
+	b.Grow(sha1.Size + len(valueKeySuffix))
 	b.Write(h.Sum(nil))
-	b.Write(mdKeySuffix)
+	b.Write(valueKeySuffix)
 	mh, _ := multihash.Encode(b.Bytes(), multihash.IDENTITY)
 	return mh
 }

--- a/store/storethehash/storethehash.go
+++ b/store/storethehash/storethehash.go
@@ -19,6 +19,10 @@ import (
 	"golang.org/x/crypto/blake2b"
 )
 
+// valueKeySize is the number of bytes of hash(providerID + contextID) used as
+// key to lookup values.
+const valueKeySize = 20
+
 var (
 	indexKeySuffix = []byte("I")
 	valueKeySuffix = []byte("M")
@@ -514,7 +518,7 @@ func makeValueKey(value indexer.Value) multihash.Multihash {
 	// Create a hash of the ProviderID and ContextID so that the key length is
 	// fixed.  This hash is used to look up the Value, which contains
 	// ProviderID, ContextID, and Metadata.
-	h, err := blake2b.New256(nil)
+	h, err := blake2b.New(valueKeySize, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/store/storethehash/storethehash_test.go
+++ b/store/storethehash/storethehash_test.go
@@ -112,3 +112,15 @@ func TestPeriodicFlush(t *testing.T) {
 		t.Errorf("Got wrong value for single multihash")
 	}
 }
+
+func TestClose(t *testing.T) {
+	s := initSth(t)
+	err := s.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = s.Close(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/store/test/tests.go
+++ b/store/test/tests.go
@@ -58,6 +58,13 @@ func E2ETest(t *testing.T, s indexer.Interface) {
 		t.Fatalf("Error putting single multihash: %s", err)
 	}
 
+	// Put same value again.
+	t.Log("Put/Get single multihash again")
+	err = s.Put(value1, single)
+	if err != nil {
+		t.Fatalf("Error putting single multihash again: %s", err)
+	}
+
 	vals, found, err := s.Get(single)
 	if err != nil {
 		t.Fatal(err)

--- a/value.go
+++ b/value.go
@@ -16,7 +16,7 @@ type Value struct {
 	ContextID []byte `json:"c"`
 	// MetadataBytes is serialized metadata.  The is kept serialized, because
 	// the indexer only uses the serialized form of this data.
-	MetadataBytes []byte `json:",omitempty"`
+	MetadataBytes []byte `json:"m,omitempty"`
 }
 
 // Match return true if both values have the same ProviderID and ContextID.
@@ -55,13 +55,13 @@ func UnmarshalValue(b []byte) (Value, error) {
 //
 // TODO: Switch from JSON to a more efficient serialization
 // format once we figure out the right data structure?
-func MarshalValues(vals []Value) ([]byte, error) {
-	return json.Marshal(&vals)
+func MarshalValueKeys(valKeys [][]byte) ([]byte, error) {
+	return json.Marshal(&valKeys)
 }
 
-// Unmarshal serialized Value list
-func UnmarshalValues(b []byte) ([]Value, error) {
-	vals := []Value{}
-	err := json.Unmarshal(b, &vals)
-	return vals, err
+// Unmarshal serialized value keys list
+func UnmarshalValueKeys(b []byte) ([][]byte, error) {
+	var valKeys [][]byte
+	err := json.Unmarshal(b, &valKeys)
+	return valKeys, err
 }


### PR DESCRIPTION
Previously each multihash was mapped to an encoded (providerID + contextID), and that was used to lookup the metadata.  This change maps each multihash to a sha1 hash of (providerID + contextID) and uses that to look up the value (providerID, contextID, metadata).

The reduces the storage size to less than a third of what was previously required.  The current figures are this:
Our sample of 320GB of car files generates 1231833 indexes.  This results in 130MB of indexer storage used.
Rough estimates:
- 1e6 indexes require 105MB of indexer storage.
- 1TB of content will require 400M of index storage