### PR TITLE
Add valuestore garbage collection functionality

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -193,7 +193,7 @@ func (e *Engine) Close() error {
 	return e.valueStore.Close()
 }
 
-func (e *Engine) GC(ctx context.Context) (int, error) {
+func (e *Engine) GC(ctx context.Context) (int, int, error) {
 	return e.valueStore.GC(ctx)
 }
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -193,6 +193,10 @@ func (e *Engine) Close() error {
 	return e.valueStore.Close()
 }
 
+func (e *Engine) GC() (int, error) {
+	return e.valueStore.GC()
+}
+
 func (e *Engine) Iter() (indexer.Iterator, error) {
 	return e.valueStore.Iter()
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -193,8 +193,8 @@ func (e *Engine) Close() error {
 	return e.valueStore.Close()
 }
 
-func (e *Engine) GC() (int, error) {
-	return e.valueStore.GC()
+func (e *Engine) GC(ctx context.Context) (int, error) {
+	return e.valueStore.GC(ctx)
 }
 
 func (e *Engine) Iter() (indexer.Iterator, error) {

--- a/interface.go
+++ b/interface.go
@@ -44,8 +44,9 @@ type Interface interface {
 	Close() error
 
 	// GC performs garbage collection by removing all multihashes that do not
-	// map to any values.
-	GC(context.Context) (int, error)
+	// map to any values.  Returns the number of multihash-value mapping
+	// removed and remaining.
+	GC(context.Context) (int, int, error)
 
 	// Iter creates a new value store iterator.
 	Iter() (Iterator, error)

--- a/interface.go
+++ b/interface.go
@@ -1,6 +1,8 @@
 package indexer
 
 import (
+	"context"
+
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/multiformats/go-multihash"
 )
@@ -43,7 +45,7 @@ type Interface interface {
 
 	// GC performs garbage collection by removing all multihashes that do not
 	// map to any values.
-	GC() (int, error)
+	GC(context.Context) (int, error)
 
 	// Iter creates a new value store iterator.
 	Iter() (Iterator, error)

--- a/interface.go
+++ b/interface.go
@@ -41,6 +41,10 @@ type Interface interface {
 	// Close gracefully closes the store flushing all pending data from memory,
 	Close() error
 
+	// GC performs garbage collection by removing all multihashes that do not
+	// map to any values.
+	GC() (int, error)
+
 	// Iter creates a new value store iterator.
 	Iter() (Iterator, error)
 }

--- a/store/memory/memory.go
+++ b/store/memory/memory.go
@@ -184,6 +184,8 @@ func (s *memoryStore) Flush() error { return nil }
 
 func (s *memoryStore) Close() error { return nil }
 
+func (s *memoryStore) GC() (int, error) { return 0, nil }
+
 func (s *memoryStore) Iter() (indexer.Iterator, error) {
 	return &memoryIter{
 		iter: s.rtree.Iter(),

--- a/store/memory/memory.go
+++ b/store/memory/memory.go
@@ -10,6 +10,7 @@ package memory
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -184,7 +185,7 @@ func (s *memoryStore) Flush() error { return nil }
 
 func (s *memoryStore) Close() error { return nil }
 
-func (s *memoryStore) GC() (int, error) { return 0, nil }
+func (s *memoryStore) GC(_ context.Context) (int, error) { return 0, nil }
 
 func (s *memoryStore) Iter() (indexer.Iterator, error) {
 	return &memoryIter{

--- a/store/memory/memory.go
+++ b/store/memory/memory.go
@@ -185,7 +185,7 @@ func (s *memoryStore) Flush() error { return nil }
 
 func (s *memoryStore) Close() error { return nil }
 
-func (s *memoryStore) GC(_ context.Context) (int, error) { return 0, nil }
+func (s *memoryStore) GC(_ context.Context) (int, int, error) { return 0, s.rtree.Len(), nil }
 
 func (s *memoryStore) Iter() (indexer.Iterator, error) {
 	return &memoryIter{

--- a/store/pogreb/pogreb.go
+++ b/store/pogreb/pogreb.go
@@ -8,6 +8,7 @@ package pogreb
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -183,7 +184,7 @@ func (s *pStorage) Close() error {
 	return err
 }
 
-func (s *pStorage) GC() (int, error) {
+func (s *pStorage) GC(ctx context.Context) (int, error) {
 	if err := s.store.Sync(); err != nil {
 		return 0, err
 	}
@@ -191,6 +192,10 @@ func (s *pStorage) GC() (int, error) {
 	var removed int
 	iter := s.store.Items()
 	for {
+		if ctx.Err() != nil {
+			return removed, ctx.Err()
+		}
+
 		key, valKeysData, err := iter.Next()
 		if err != nil {
 			if err == pogreb.ErrIterationDone {

--- a/store/pogreb/pogreb_test.go
+++ b/store/pogreb/pogreb_test.go
@@ -91,6 +91,16 @@ func TestClose(t *testing.T) {
 	}
 }
 
+func TestGC(t *testing.T) {
+	skipIf32bit(t)
+
+	s := initPogreb(t)
+	test.GCTest(t, s)
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func skipIf32bit(t *testing.T) {
 	if runtime.GOARCH == "386" {
 		t.Skip("Pogreb cannot use GOARCH=386")

--- a/store/storethehash/storethehash.go
+++ b/store/storethehash/storethehash.go
@@ -2,6 +2,7 @@ package storethehash
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -208,7 +209,7 @@ func (s *sthStorage) Close() error {
 	return s.store.Close()
 }
 
-func (s *sthStorage) GC() (int, error) {
+func (s *sthStorage) GC(ctx context.Context) (int, error) {
 	s.Flush()
 	iter, err := s.primary.Iter()
 	if err != nil {
@@ -218,6 +219,10 @@ func (s *sthStorage) GC() (int, error) {
 
 	var removed int
 	for {
+		if ctx.Err() != nil {
+			return removed, ctx.Err()
+		}
+
 		key, _, err := iter.Next()
 		if err != nil {
 			if err == io.EOF {

--- a/store/storethehash/storethehash_test.go
+++ b/store/storethehash/storethehash_test.go
@@ -134,3 +134,11 @@ func TestClose(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestGC(t *testing.T) {
+	s := initSth(t)
+	test.GCTest(t, s)
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/store/test/tests.go
+++ b/store/test/tests.go
@@ -724,41 +724,44 @@ func GCTest(t *testing.T, s indexer.Interface) {
 		t.Fatal(err)
 	}
 
+	ctx := context.Background()
+
 	t.Log("Removing provider1 context1")
 	// This only deltes multihashes from batch1, because the batch2
 	// multihatches still point to value2.
 	if err = s.RemoveProviderContext(prov1, ctx1id); err != nil {
 		t.Fatalf("Error removing provider context: %s", err)
 	}
-
-	ctx := context.Background()
-
-	removed, err := s.GC(ctx)
+	removed, remaining, err := s.GC(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if removed != len(batch1) {
-		t.Logf("GC removed %d multihashes, expected %d", removed, len(batch1))
+	// Both batch1 and batch2 mapped to the value with prov1/ctxid1.
+	if removed != len(batch1)+len(batch2) {
+		t.Fatalf("GC removed %d multihashes, expected %d", removed, len(batch1)+len(batch2))
 	}
+	t.Logf("GC removed=%d, remaining=%d", removed, remaining)
 
-	removed, err = s.GC(ctx)
+	removed, remaining, err = s.GC(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if removed != 0 {
-		t.Logf("GC removed %d multihashes, expected 0", removed)
+		t.Fatalf("GC removed %d multihashes, expected 0", removed)
 	}
+	t.Logf("GC removed=%d, remaining=%d", removed, remaining)
 
 	t.Log("Removing provider1 context2")
 	if err = s.RemoveProviderContext(prov1, ctx2id); err != nil {
 		t.Fatalf("Error removing provider context: %s", err)
 	}
-
-	removed, err = s.GC(ctx)
+	removed, remaining, err = s.GC(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if removed != len(batch2) {
-		t.Logf("GC removed %d multihashes, expected %d", removed, len(batch2))
+	// Both batch2 and batch3 mapped to the value with prov1/ctxid1.
+	if removed != len(batch2)+len(batch3) {
+		t.Fatalf("GC removed %d multihashes, expected %d", removed, len(batch2)+len(batch3))
 	}
+	t.Logf("GC removed=%d, remaining=%d", removed, remaining)
 }

--- a/store/test/tests.go
+++ b/store/test/tests.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"io"
 	"sync"
 	"testing"
@@ -730,7 +731,9 @@ func GCTest(t *testing.T, s indexer.Interface) {
 		t.Fatalf("Error removing provider context: %s", err)
 	}
 
-	removed, err := s.GC()
+	ctx := context.Background()
+
+	removed, err := s.GC(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -738,7 +741,7 @@ func GCTest(t *testing.T, s indexer.Interface) {
 		t.Logf("GC removed %d multihashes, expected %d", removed, len(batch1))
 	}
 
-	removed, err = s.GC()
+	removed, err = s.GC(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -751,7 +754,7 @@ func GCTest(t *testing.T, s indexer.Interface) {
 		t.Fatalf("Error removing provider context: %s", err)
 	}
 
-	removed, err = s.GC()
+	removed, err = s.GC(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Value stores now provide a GC function that performs garbage collection by removing all multihashes that do not map to any values.

These orphaned multihashes are caused by deleting provider values by contextID or by providerID.  Since the core does not store the mapping of provider value to all multihashes, only the provider value is deleted.  When multihashes are queried or interated, those that have no remaining provider values are deleted and produce no results.  The multihashes for deleted values are often never read, so GC is needed to get rid of them.  Calling GC occasionally will prevent orphaned multihashes from building up in the value store.