### PR TITLE
Make value serialization format pluggable and add binary format

### DIFF
--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func initEngine(t *testing.T, withCache, cacheOnPut bool) *Engine {
-	valueStore, err := storethehash.New(context.Background(), t.TempDir())
+	valueStore, err := storethehash.New(context.Background(), t.TempDir(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/ipld/go-storethehash v0.2.0
 	github.com/libp2p/go-libp2p-core v0.16.1
 	github.com/multiformats/go-multihash v0.1.0
+	github.com/multiformats/go-varint v0.0.6
 	go.opencensus.io v0.23.0
 	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871
 )
@@ -33,7 +34,6 @@ require (
 	github.com/multiformats/go-multiaddr v0.4.1 // indirect
 	github.com/multiformats/go-multibase v0.0.3 // indirect
 	github.com/multiformats/go-multicodec v0.4.1 // indirect
-	github.com/multiformats/go-varint v0.0.6 // indirect
 	github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect

--- a/store/pogreb/pogreb.go
+++ b/store/pogreb/pogreb.go
@@ -41,6 +41,7 @@ type pStorage struct {
 	store   *pogreb.DB
 	mlk     *keymutex.KeyMutex
 	valLock sync.RWMutex
+	vserde  indexer.ValueSerde
 }
 
 type pogrebIter struct {
@@ -50,17 +51,23 @@ type pogrebIter struct {
 
 // New creates a new indexer.Interface implemented by a pogreb-based value
 // store.
-func New(dir string) (indexer.Interface, error) {
+//
+// The given indexer.ValueSerde is used to serialize and deserialize values.
+// If it is set to nil, indexer.JsonValueSerde is used.
+func New(dir string, vserde indexer.ValueSerde) (indexer.Interface, error) {
 	opts := pogreb.Options{BackgroundSyncInterval: DefaultSyncInterval}
-
+	if vserde == nil {
+		vserde = indexer.JsonValueSerde{}
+	}
 	s, err := pogreb.Open(dir, &opts)
 	if err != nil {
 		return nil, err
 	}
 	return &pStorage{
-		dir:   dir,
-		store: s,
-		mlk:   keymutex.New(0),
+		dir:    dir,
+		store:  s,
+		mlk:    keymutex.New(0),
+		vserde: vserde,
 	}, nil
 }
 
@@ -127,7 +134,7 @@ func (s *pStorage) RemoveProvider(ctx context.Context, providerID peer.ID) error
 		// If a value was found, skip it if the provider is different than the
 		// one being removed.
 		if valueData != nil {
-			value, err := indexer.UnmarshalValue(valueData)
+			value, err := s.vserde.UnmarshalValue(valueData)
 			if err != nil {
 				return err
 			}
@@ -214,7 +221,7 @@ func (it *pogrebIter) Next() (multihash.Multihash, []indexer.Value, error) {
 			continue
 		}
 
-		valueKeys, err := indexer.UnmarshalValueKeys(valKeysData)
+		valueKeys, err := it.s.vserde.UnmarshalValueKeys(valKeysData)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -241,7 +248,7 @@ func (s *pStorage) getValueKeys(k []byte) ([][]byte, error) {
 		return nil, nil
 	}
 
-	return indexer.UnmarshalValueKeys(valueKeysData)
+	return s.vserde.UnmarshalValueKeys(valueKeysData)
 }
 
 func (s *pStorage) get(k []byte) ([]indexer.Value, bool, error) {
@@ -285,7 +292,7 @@ func (s *pStorage) putIndex(m multihash.Multihash, valKey []byte) error {
 	}
 
 	// Store the new list of value keys for the multihash.
-	b, err := indexer.MarshalValueKeys(append(existingValKeys, valKey))
+	b, err := s.vserde.MarshalValueKeys(append(existingValKeys, valKey))
 	if err != nil {
 		return err
 	}
@@ -321,7 +328,7 @@ func (s *pStorage) removeIndex(m multihash.Multihash, value indexer.Value) error
 			valueKeys[len(valueKeys)-1] = nil
 			valueKeys = valueKeys[:len(valueKeys)-1]
 			// Update the list of value-keys that the multihash maps to.
-			b, err := indexer.MarshalValueKeys(valueKeys)
+			b, err := s.vserde.MarshalValueKeys(valueKeys)
 			if err != nil {
 				return err
 			}
@@ -351,7 +358,7 @@ func (s *pStorage) updateValue(value indexer.Value, saveNew bool) ([]byte, error
 	if valData == nil {
 		if saveNew {
 			// Store the new value.
-			valData, err := indexer.MarshalValue(value)
+			valData, err := s.vserde.MarshalValue(value)
 			if err != nil {
 				return nil, err
 			}
@@ -364,7 +371,7 @@ func (s *pStorage) updateValue(value indexer.Value, saveNew bool) ([]byte, error
 	}
 
 	// Found previous value.  If it is different, then update it.
-	newValData, err := indexer.MarshalValue(value)
+	newValData, err := s.vserde.MarshalValue(value)
 	if err != nil {
 		return nil, err
 	}
@@ -406,7 +413,7 @@ func (s *pStorage) getValues(key []byte, valueKeys [][]byte) ([]indexer.Value, e
 			valueKeys = valueKeys[:len(valueKeys)-1]
 			continue
 		}
-		val, err := indexer.UnmarshalValue(valData)
+		val, err := s.vserde.UnmarshalValue(valData)
 		if err != nil {
 			s.valLock.RUnlock()
 			return nil, err
@@ -431,7 +438,7 @@ func (s *pStorage) getValues(key []byte, valueKeys [][]byte) ([]indexer.Value, e
 		}
 
 		// Update the values this multihash maps to.
-		b, err := indexer.MarshalValueKeys(valueKeys)
+		b, err := s.vserde.MarshalValueKeys(valueKeys)
 		if err != nil {
 			return nil, err
 		}

--- a/store/pogreb/pogreb_bench_test.go
+++ b/store/pogreb/pogreb_bench_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func initBenchStore(b *testing.B) indexer.Interface {
-	s, err := pogreb.New(b.TempDir())
+	s, err := pogreb.New(b.TempDir(), nil)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/store/pogreb/pogreb_test.go
+++ b/store/pogreb/pogreb_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func initPogreb(t *testing.T) indexer.Interface {
-	s, err := pogreb.New(t.TempDir())
+	s, err := pogreb.New(t.TempDir(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/store/storethehash/storethehash_bench_test.go
+++ b/store/storethehash/storethehash_bench_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func initBenchStore(b *testing.B) indexer.Interface {
-	s, err := storethehash.New(context.Background(), b.TempDir())
+	s, err := storethehash.New(context.Background(), b.TempDir(), nil)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/store/storethehash/storethehash_test.go
+++ b/store/storethehash/storethehash_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func initSth(t *testing.T) indexer.Interface {
-	s, err := storethehash.New(context.Background(), t.TempDir())
+	s, err := storethehash.New(context.Background(), t.TempDir(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +74,7 @@ func TestPeriodicFlush(t *testing.T) {
 
 	syncInterval := 200 * time.Millisecond
 
-	s, err := storethehash.New(context.Background(), tmpDir, sth.SyncInterval(syncInterval))
+	s, err := storethehash.New(context.Background(), tmpDir, nil, sth.SyncInterval(syncInterval))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,7 +100,7 @@ func TestPeriodicFlush(t *testing.T) {
 	time.Sleep(2 * syncInterval)
 
 	// Regenerate new storage
-	s2, err := storethehash.New(context.Background(), tmpDir)
+	s2, err := storethehash.New(context.Background(), tmpDir, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/value.go
+++ b/value.go
@@ -3,21 +3,56 @@ package indexer
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
 
 	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/multiformats/go-varint"
 )
 
-// Value is the value of an index entry that is stored for each multihash in
-// the indexer.
-type Value struct {
-	// PrividerID is the peer ID of the provider of the multihash.
-	ProviderID peer.ID `json:"p"`
-	// ContextID identifies the metadata that is part of this value.
-	ContextID []byte `json:"c"`
-	// MetadataBytes is serialized metadata. The is kept serialized, because
-	// the indexer only uses the serialized form of this data.
-	MetadataBytes []byte `json:"m,omitempty"`
-}
+var (
+	_ ValueSerde = (*JsonValueSerde)(nil)
+	_ ValueSerde = (*BinaryValueSerde)(nil)
+
+	// ErrSerdeOverflow signals that unexpected size was encountered while
+	// unmarshalling bytes to Value.
+	ErrSerdeOverflow = errors.New("overflow")
+)
+
+type (
+	// Value is the value of an index entry that is stored for each multihash in
+	// the indexer.
+	Value struct {
+		// ProviderID is the peer ID of the provider of the multihash.
+		ProviderID peer.ID `json:"p"`
+		// ContextID identifies the metadata that is part of this value.
+		ContextID []byte `json:"c"`
+		// MetadataBytes is serialized metadata. The is kept serialized, because
+		// the indexer only uses the serialized form of this data.
+		MetadataBytes []byte `json:"m,omitempty"`
+	}
+
+	// ValueSerde represents Value serializer and deserializer to/from bytes.
+	ValueSerde interface {
+		// MarshalValue serializes a single value.
+		MarshalValue(Value) ([]byte, error)
+		// UnmarshalValue deserializes a single value.
+		UnmarshalValue(b []byte) (Value, error)
+		// MarshalValueKeys serializes a Value list for storage.
+		MarshalValueKeys([][]byte) ([]byte, error)
+		// UnmarshalValueKeys deserializes value keys list.
+		UnmarshalValueKeys([]byte) ([][]byte, error)
+	}
+
+	// JsonValueSerde serializes and deserializes Value as JSON.
+	// See: json.Marshal, json.Unmarshal
+	JsonValueSerde struct{}
+
+	// BinaryValueSerde serializes and deserializes Value as binary sections
+	// prepended with byte length as varint.
+	BinaryValueSerde struct{}
+)
 
 // Match return true if both values have the same ProviderID and ContextID.
 func (v Value) Match(other Value) bool {
@@ -40,28 +75,145 @@ func (v Value) MatchEqual(other Value) (isMatch bool, isEqual bool) {
 	return
 }
 
-// MarshalValue serializes a single value
-func MarshalValue(value Value) ([]byte, error) {
-	return json.Marshal(&value)
+func (JsonValueSerde) MarshalValue(v Value) ([]byte, error) {
+	return json.Marshal(&v)
 }
 
-func UnmarshalValue(b []byte) (Value, error) {
-	var value Value
-	err := json.Unmarshal(b, &value)
-	return value, err
+func (JsonValueSerde) UnmarshalValue(b []byte) (v Value, err error) {
+	err = json.Unmarshal(b, &v)
+	return
 }
 
-// MarshalValues serializes a Value list for storage.
+func (JsonValueSerde) MarshalValueKeys(vk [][]byte) ([]byte, error) {
+	return json.Marshal(&vk)
+}
+
+func (JsonValueSerde) UnmarshalValueKeys(b []byte) (vk [][]byte, err error) {
+	err = json.Unmarshal(b, &vk)
+	return
+}
+
+func (BinaryValueSerde) MarshalValue(v Value) ([]byte, error) {
+	pid := []byte(v.ProviderID)
+	pl := len(pid)
+	upl := uint64(pl)
+	cl := len(v.ContextID)
+	ucl := uint64(cl)
+	ml := len(v.MetadataBytes)
+	uml := uint64(ml)
+	size := varint.UvarintSize(upl) + pl +
+		varint.UvarintSize(ucl) + cl +
+		varint.UvarintSize(uml) + ml
+
+	var buf bytes.Buffer
+	buf.Grow(size)
+	buf.Write(varint.ToUvarint(upl))
+	buf.Write(pid)
+	buf.Write(varint.ToUvarint(ucl))
+	buf.Write(v.ContextID)
+	buf.Write(varint.ToUvarint(uml))
+	buf.Write(v.MetadataBytes)
+	return buf.Bytes(), nil
+}
+
+// UnmarshalValue deserializes a single value.
 //
-// TODO: Switch from JSON to a more efficient serialization format once we
-// figure out the right data structure?
-func MarshalValueKeys(valKeys [][]byte) ([]byte, error) {
-	return json.Marshal(&valKeys)
+// If a failure occurs during serialization an error is returned along with
+// the partially deserialized value keys. Only nil error means complete and
+// successful deserialization.
+func (BinaryValueSerde) UnmarshalValue(b []byte) (Value, error) {
+	var v Value
+	buf := bytes.NewBuffer(b)
+
+	// Decode provider ID.
+	usize, err := varint.ReadUvarint(buf)
+	if err != nil {
+		return v, err
+	}
+	size := int(usize)
+	if size < 0 || size > buf.Len() {
+		return Value{}, ErrSerdeOverflow
+	}
+	v.ProviderID = peer.ID(buf.Next(size))
+
+	// Decode context ID.
+	usize, err = varint.ReadUvarint(buf)
+	if err != nil {
+		return v, err
+	}
+	size = int(usize)
+	if size < 0 || size > buf.Len() {
+		return v, ErrSerdeOverflow
+	}
+	v.ContextID = buf.Next(size)
+
+	// Decode metadata.
+	usize, err = varint.ReadUvarint(buf)
+	if err != nil {
+		return v, err
+	}
+	size = int(usize)
+	if size < 0 || size > buf.Len() {
+		return v, ErrSerdeOverflow
+	}
+	v.MetadataBytes = buf.Next(size)
+	if buf.Len() != 0 {
+		return v, fmt.Errorf("too many bytes; %d remain unread", buf.Len())
+	}
+	return v, nil
 }
 
-// Unmarshal serialized value keys list.
-func UnmarshalValueKeys(b []byte) ([][]byte, error) {
-	var valKeys [][]byte
-	err := json.Unmarshal(b, &valKeys)
-	return valKeys, err
+func (BinaryValueSerde) MarshalValueKeys(vk [][]byte) ([]byte, error) {
+	var buf bytes.Buffer
+	buf.Write(varint.ToUvarint(uint64(len(vk))))
+	for _, v := range vk {
+		vl := len(v)
+		uvl := uint64(vl)
+		buf.Grow(varint.UvarintSize(uvl) + vl)
+		buf.Write(varint.ToUvarint(uvl))
+		buf.Write(v)
+	}
+	return buf.Bytes(), nil
+}
+
+// UnmarshalValueKeys deserializes value keys.
+//
+// If a failure occurs during serialization an error is returned along with
+// the partially deserialized value keys. Only nil error means complete and
+// successful deserialization.
+func (BinaryValueSerde) UnmarshalValueKeys(b []byte) ([][]byte, error) {
+	var vk [][]byte
+	buf := bytes.NewBuffer(b)
+
+	// Decode vk length.
+	ulen, err := varint.ReadUvarint(buf)
+	if err != nil {
+		return vk, err
+	}
+	if ulen > math.MaxUint32 {
+		return vk, ErrSerdeOverflow
+	}
+	l := int(ulen)
+	// There should at least be l number of bytes since length of each inner byte slice length
+	// should have been written, even if it was zero, and minimum size of a uvarint is a byte.
+	if l < 0 || l > buf.Len() {
+		return vk, ErrSerdeOverflow
+	}
+
+	// Decode each value key.
+	for i := 0; i < l; i++ {
+		usize, err := varint.ReadUvarint(buf)
+		if err != nil {
+			return vk, err
+		}
+		size := int(usize)
+		if size < 0 || size > buf.Len() {
+			return vk, ErrSerdeOverflow
+		}
+		vk = append(vk, buf.Next(size))
+	}
+	if buf.Len() != 0 {
+		return vk, fmt.Errorf("too many bytes; %d remain unread", buf.Len())
+	}
+	return vk, nil
 }

--- a/value_serde_bench_test.go
+++ b/value_serde_bench_test.go
@@ -1,0 +1,115 @@
+package indexer_test
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+
+	"github.com/filecoin-project/go-indexer-core"
+	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+const (
+	providerCount     = 100
+	valuesPerProvider = 1_000
+)
+
+func BenchmarkBinaryValueSerde_MarshalValue(b *testing.B) {
+	benchmarkMarshalValue(b, indexer.BinaryValueSerde{})
+}
+
+func BenchmarkJsonValueSerde_MarshalValue(b *testing.B) {
+	benchmarkMarshalValue(b, indexer.JsonValueSerde{})
+}
+
+func BenchmarkBinaryValueSerde_UnmarshalValue(b *testing.B) {
+	benchmarkUnmarshalValue(b, indexer.BinaryValueSerde{})
+}
+
+func BenchmarkJsonValueSerde_UnmarshalValue(b *testing.B) {
+	benchmarkUnmarshalValue(b, indexer.JsonValueSerde{})
+}
+
+func benchmarkMarshalValue(b *testing.B, subject indexer.ValueSerde) {
+	values, size := generateRandomValues(b, providerCount, valuesPerProvider)
+	b.SetBytes(int64(size))
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			for _, v := range values {
+				if _, err := subject.MarshalValue(v); err != nil {
+					b.Fatal(err)
+				}
+			}
+		}
+	})
+}
+
+func benchmarkUnmarshalValue(b *testing.B, subject indexer.ValueSerde) {
+	values, size := generateRandomValues(b, providerCount, valuesPerProvider)
+	var svalues [][]byte
+	for _, v := range values {
+		sv, err := subject.MarshalValue(v)
+		if err != nil {
+			b.Fatal(err)
+		}
+		svalues = append(svalues, sv)
+	}
+	b.SetBytes(int64(size))
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			for _, sv := range svalues {
+				if _, err := subject.UnmarshalValue(sv); err != nil {
+					b.Fatal(err)
+				}
+			}
+		}
+	})
+}
+
+func generateRandomValues(b testing.TB, providerCount, valsPerProvider int) ([]indexer.Value, int) {
+	// Use fixed RNG for determinism across benchmarks.
+	rng := rand.New(rand.NewSource(1413))
+	ctxID := make([]byte, 64) // max allowed context ID size
+	md := make([]byte, 32)
+	pid := make([]byte, 32)
+	var values []indexer.Value
+	var totalSize int
+	var size int
+	var err error
+	for i := 0; i < providerCount; i++ {
+		if _, err = rng.Read(pid); err != nil {
+			b.Fatal(err)
+		}
+		_, pub, err := crypto.GenerateEd25519Key(bytes.NewReader(pid))
+		if err != nil {
+			b.Fatal(err)
+		}
+		provId, err := peer.IDFromPublicKey(pub)
+		if err != nil {
+			b.Fatal(err)
+		}
+		for j := 0; j < valsPerProvider; j++ {
+			if size, err = rng.Read(ctxID); err != nil {
+				b.Fatal(err)
+			}
+			totalSize += size
+			if size, err = rng.Read(md); err != nil {
+				b.Fatal(err)
+			}
+			totalSize += size
+			v := indexer.Value{
+				ProviderID:    provId,
+				ContextID:     ctxID,
+				MetadataBytes: md,
+			}
+			totalSize += provId.Size()
+			values = append(values, v)
+		}
+	}
+	return values, totalSize
+}

--- a/value_serde_test.go
+++ b/value_serde_test.go
@@ -1,0 +1,170 @@
+package indexer_test
+
+import (
+	"bytes"
+	"math/rand"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/filecoin-project/go-indexer-core"
+	"github.com/multiformats/go-varint"
+)
+
+func TestValueSerde_MarshalUnmarshal(t *testing.T) {
+	wantValues, _ := generateRandomValues(t, 14, 13)
+	wantValueKeys := generateRandomValueKeys(43)
+
+	tests := []struct {
+		name    string
+		subject indexer.ValueSerde
+	}{
+		{
+			name:    "json",
+			subject: indexer.JsonValueSerde{},
+		},
+		{
+			name:    "binary",
+			subject: indexer.BinaryValueSerde{},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for _, wantValue := range wantValues {
+				gotSer, err := test.subject.MarshalValue(wantValue)
+				if err != nil {
+					t.Fatal(err)
+				}
+				gotValue, err := test.subject.UnmarshalValue(gotSer)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !reflect.DeepEqual(wantValue, gotValue) {
+					t.Fatalf("value mismatch; wanted %v but got %v", wantValue, gotValue)
+				}
+			}
+			gotSer, err := test.subject.MarshalValueKeys(wantValueKeys)
+			if err != nil {
+				t.Fatal(err)
+			}
+			gotValueKeys, err := test.subject.UnmarshalValueKeys(gotSer)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(wantValueKeys, gotValueKeys) {
+				t.Fatalf("valuekeys mismatch; wanted %v but got %v", wantValueKeys, gotValueKeys)
+			}
+		})
+	}
+}
+
+func TestBinaryValueSerde_MarshalValueMalformedBytes(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   func(buf *bytes.Buffer)
+		wantErr string
+	}{
+		{
+			name: "large pid len",
+			value: func(buf *bytes.Buffer) {
+				buf.Write(varint.ToUvarint(1<<63 - 1))
+			},
+			wantErr: "overflow",
+		},
+		{
+			name: "wrong context ID len",
+			value: func(buf *bytes.Buffer) {
+				pid := []byte("fish")
+				buf.Write(varint.ToUvarint(uint64(len(pid))))
+				buf.Write(pid)
+				buf.Write(varint.ToUvarint(51))
+				buf.WriteByte(2)
+				buf.Write(varint.ToUvarint(1))
+				buf.WriteByte(0)
+			},
+			wantErr: "overflow",
+		},
+		{
+			name: "wrong metadata len",
+			value: func(buf *bytes.Buffer) {
+				pid := []byte("fish")
+				buf.Write(varint.ToUvarint(uint64(len(pid))))
+				buf.Write(pid)
+				buf.Write(varint.ToUvarint(1))
+				buf.WriteByte(2)
+				buf.Write(varint.ToUvarint(41))
+				buf.WriteByte(0)
+			},
+			wantErr: "overflow",
+		},
+		{
+			name: "bytes leftover",
+			value: func(buf *bytes.Buffer) {
+				pid := []byte("fish")
+				buf.Write(varint.ToUvarint(uint64(len(pid))))
+				buf.Write(pid)
+				ctxID := []byte("lobster")
+				buf.Write(varint.ToUvarint(uint64(len(ctxID))))
+				buf.Write(ctxID)
+				md := []byte("barreleye")
+				buf.Write(varint.ToUvarint(uint64(len(md))))
+				buf.Write(md)
+				buf.Write([]byte("undadasea"))
+			},
+			wantErr: "too many bytes",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			subject := indexer.BinaryValueSerde{}
+			buf := bytes.Buffer{}
+			test.value(&buf)
+			_, err := subject.UnmarshalValue(buf.Bytes())
+			if err == nil {
+				t.Fatalf("expected error '%s' but got no error", test.wantErr)
+			}
+			if !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("expected error '%s' but got: %v", test.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestBinaryValueSerde_MarshalUnmarshalEmptyValues(t *testing.T) {
+	subject := indexer.BinaryValueSerde{}
+	sv, err := subject.MarshalValue(indexer.Value{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(sv, []byte{0, 0, 0}) {
+		t.Fatal()
+	}
+	var emptyVK [][]byte
+	svk, err := subject.MarshalValueKeys(emptyVK)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(svk, []byte{0}) {
+		t.Fatal()
+	}
+
+	emptyVKWithEmptyK := [][]byte{{}}
+	svk, err = subject.MarshalValueKeys(emptyVKWithEmptyK)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(svk, []byte{1, 0}) {
+		t.Fatal()
+	}
+}
+
+func generateRandomValueKeys(count int) [][]byte {
+	var vks [][]byte
+	rng := rand.New(rand.NewSource(1413))
+	for i := 0; i < count; i++ {
+		vk := make([]byte, rng.Intn(127)+1)
+		vks = append(vks, vk)
+	}
+	return vks
+}

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.3.0"
+  "version": "v0.4.0"
 }


### PR DESCRIPTION
The indexer value serliazation format was hard-coded to JSON. This
forced users to use JSON, which offers good human readability but does
not offer the best performance characteristic should a user want to
trade readability with IO performance for example.

Make the serialization mechanism configurable by introducing
`ValueSerde` interface. Wrap the existing serialization functionality to
an implementation of the interface, called `JsonValueSerde` and set it
as the default serialization format for backward compatibility.

Considering the majority of data being stored by indexer engine is
already in binary format, introduce `BinaryValueSerde`.

Add a benchmark that compares the performance of both implementations.