### PR TITLE
Make binary serialization of value keys appendable

### DIFF
--- a/value_serde_test.go
+++ b/value_serde_test.go
@@ -145,7 +145,7 @@ func TestBinaryValueSerde_MarshalUnmarshalEmptyValues(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(svk, []byte{0}) {
+	if len(svk) != 0 {
 		t.Fatal()
 	}
 
@@ -154,7 +154,7 @@ func TestBinaryValueSerde_MarshalUnmarshalEmptyValues(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(svk, []byte{1, 0}) {
+	if !reflect.DeepEqual(svk, []byte{0}) {
 		t.Fatal()
 	}
 }


### PR DESCRIPTION
The previous binary serialisation format for value-keys, which is a 2D
slice of bytes, started the number rows. This meant that given a set of
bytes the function could determine how many rows to expect. But the
tradeoff is that in order to append a new row to an existing serialized
value-keys one had to change the uvarint representing the number of
rows at the beginning of the value. Because the size is a uvarint, this
could mean shifting bytes, etc.

Instead, do not bother with storing the number of rows at all. Instead,
simply keep reading a uvarint-sized bytes and expect that reading the
last row should result in no leftover bytes.

This allows further optimisations inside the store implementations,
where rather than reading the entire value of value-keys from the store
adding a value and re-serializing it, one could simply append a new
value to the end of the already serialized value-keys.