### PR TITLE
Rename the term `serde` to `codec`

### DIFF
--- a/value_codec_bench_test.go
+++ b/value_codec_bench_test.go
@@ -15,23 +15,23 @@ const (
 	valuesPerProvider = 1_000
 )
 
-func BenchmarkBinaryValueSerde_MarshalValue(b *testing.B) {
-	benchmarkMarshalValue(b, indexer.BinaryValueSerde{})
+func BenchmarkBinaryValueCodec_MarshalValue(b *testing.B) {
+	benchmarkMarshalValue(b, indexer.BinaryValueCodec{})
 }
 
-func BenchmarkJsonValueSerde_MarshalValue(b *testing.B) {
-	benchmarkMarshalValue(b, indexer.JsonValueSerde{})
+func BenchmarkJsonValueCodec_MarshalValue(b *testing.B) {
+	benchmarkMarshalValue(b, indexer.JsonValueCodec{})
 }
 
-func BenchmarkBinaryValueSerde_UnmarshalValue(b *testing.B) {
-	benchmarkUnmarshalValue(b, indexer.BinaryValueSerde{})
+func BenchmarkBinaryValueCodec_UnmarshalValue(b *testing.B) {
+	benchmarkUnmarshalValue(b, indexer.BinaryValueCodec{})
 }
 
-func BenchmarkJsonValueSerde_UnmarshalValue(b *testing.B) {
-	benchmarkUnmarshalValue(b, indexer.JsonValueSerde{})
+func BenchmarkJsonValueCodec_UnmarshalValue(b *testing.B) {
+	benchmarkUnmarshalValue(b, indexer.JsonValueCodec{})
 }
 
-func benchmarkMarshalValue(b *testing.B, subject indexer.ValueSerde) {
+func benchmarkMarshalValue(b *testing.B, subject indexer.ValueCodec) {
 	values, size := generateRandomValues(b, providerCount, valuesPerProvider)
 	b.SetBytes(int64(size))
 	b.ReportAllocs()
@@ -47,7 +47,7 @@ func benchmarkMarshalValue(b *testing.B, subject indexer.ValueSerde) {
 	})
 }
 
-func benchmarkUnmarshalValue(b *testing.B, subject indexer.ValueSerde) {
+func benchmarkUnmarshalValue(b *testing.B, subject indexer.ValueCodec) {
 	values, size := generateRandomValues(b, providerCount, valuesPerProvider)
 	var svalues [][]byte
 	for _, v := range values {

--- a/value_codec_test.go
+++ b/value_codec_test.go
@@ -11,21 +11,21 @@ import (
 	"github.com/multiformats/go-varint"
 )
 
-func TestValueSerde_MarshalUnmarshal(t *testing.T) {
+func TestValueCodec_MarshalUnmarshal(t *testing.T) {
 	wantValues, _ := generateRandomValues(t, 14, 13)
 	wantValueKeys := generateRandomValueKeys(43)
 
 	tests := []struct {
 		name    string
-		subject indexer.ValueSerde
+		subject indexer.ValueCodec
 	}{
 		{
 			name:    "json",
-			subject: indexer.JsonValueSerde{},
+			subject: indexer.JsonValueCodec{},
 		},
 		{
 			name:    "binary",
-			subject: indexer.BinaryValueSerde{},
+			subject: indexer.BinaryValueCodec{},
 		},
 	}
 	for _, test := range tests {
@@ -58,7 +58,7 @@ func TestValueSerde_MarshalUnmarshal(t *testing.T) {
 	}
 }
 
-func TestBinaryValueSerde_MarshalValueMalformedBytes(t *testing.T) {
+func TestBinaryValueCodec_MarshalValueMalformedBytes(t *testing.T) {
 	tests := []struct {
 		name    string
 		value   func(buf *bytes.Buffer)
@@ -117,7 +117,7 @@ func TestBinaryValueSerde_MarshalValueMalformedBytes(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 
-			subject := indexer.BinaryValueSerde{}
+			subject := indexer.BinaryValueCodec{}
 			buf := bytes.Buffer{}
 			test.value(&buf)
 			_, err := subject.UnmarshalValue(buf.Bytes())
@@ -131,8 +131,8 @@ func TestBinaryValueSerde_MarshalValueMalformedBytes(t *testing.T) {
 	}
 }
 
-func TestBinaryValueSerde_MarshalUnmarshalEmptyValues(t *testing.T) {
-	subject := indexer.BinaryValueSerde{}
+func TestBinaryValueCodec_MarshalUnmarshalEmptyValues(t *testing.T) {
+	subject := indexer.BinaryValueCodec{}
 	sv, err := subject.MarshalValue(indexer.Value{})
 	if err != nil {
 		t.Fatal(err)

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.4.0"
+  "version": "v0.5.0"
 }


### PR DESCRIPTION
Rename to a more familiar term for better human readability.