### PR TITLE
Number of key-locks should be same as concurrency

### DIFF
--- a/store/storethehash/storethehash.go
+++ b/store/storethehash/storethehash.go
@@ -87,7 +87,7 @@ func New(ctx context.Context, dir string, vcodec indexer.ValueCodec, putConcurre
 	return &sthStorage{
 		dir:     dir,
 		store:   s,
-		mlk:     keymutex.New(0),
+		mlk:     keymutex.New(putConcurrency),
 		vlk:     keymutex.NewRW(0),
 		primary: primary,
 		vcodec:  vcodec,


### PR DESCRIPTION
This is to minimize contention between different keys