### PR TITLE
Bump version in prepration for releasing pebble backing store

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-    "version": "v0.5.5"
+    "version": "v0.6.0"
 }


### PR DESCRIPTION
Bump version to 0.6.0 because of the breaking change in `Iter` API where
it is changed to also implement the closer interface for releasing
resources after iteration.