### PR TITLE
Gracefully migrate from JSON to Binary value encoding by default

### DIFF
--- a/store/pogreb/pogreb.go
+++ b/store/pogreb/pogreb.go
@@ -53,11 +53,12 @@ type pogrebIter struct {
 // store.
 //
 // The given indexer.ValueCodec is used to serialize and deserialize values.
-// If it is set to nil, indexer.JsonValueCodec is used.
+// If it is set to nil, indexer.BinaryWithJsonFallbackCodec is used which
+// will gracefully migrate the codec from JSON to Binary format.
 func New(dir string, vcodec indexer.ValueCodec) (indexer.Interface, error) {
 	opts := pogreb.Options{BackgroundSyncInterval: DefaultSyncInterval}
 	if vcodec == nil {
-		vcodec = indexer.JsonValueCodec{}
+		vcodec = indexer.BinaryWithJsonFallbackCodec{}
 	}
 	s, err := pogreb.Open(dir, &opts)
 	if err != nil {

--- a/store/storethehash/storethehash.go
+++ b/store/storethehash/storethehash.go
@@ -60,7 +60,8 @@ type sthIterator struct {
 // value store.
 //
 // The given indexer.ValueCodec is used to serialize and deserialize values.
-// If it is set to nil, indexer.JsonValueCodec is used.
+// If it is set to nil, indexer.BinaryWithJsonFallbackCodec is used which
+// // will gracefully migrate the codec from JSON to Binary format.
 func New(ctx context.Context, dir string, vcodec indexer.ValueCodec, putConcurrency int, options ...sth.Option) (*SthStorage, error) {
 	// Using a single file to store index and data. This may change in the
 	// future, and we may choose to set a max. size to files. Having several
@@ -78,7 +79,7 @@ func New(ctx context.Context, dir string, vcodec indexer.ValueCodec, putConcurre
 		return nil, fmt.Errorf("error opening storethehash index: %w", err)
 	}
 	if vcodec == nil {
-		vcodec = indexer.JsonValueCodec{}
+		vcodec = indexer.BinaryWithJsonFallbackCodec{}
 	}
 	s.Start()
 	var wp *workerpool.WorkerPool


### PR DESCRIPTION
Define a new value codec that always serializes to binary but understands both JSON and Binary format on deserialization. The idea is to gracefully and opportunistically migrate  codec from JSON to the more efficient binary format.

Use the newly defined codec as the default value codec for stores that support configuring it: pogreb and sth.

Fixes #84