### PR TITLE
Use sth with primary GC

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/gammazero/workerpool v1.1.3
 	github.com/ipfs/go-cid v0.2.0
 	github.com/ipfs/go-log/v2 v2.5.1
-	github.com/ipld/go-storethehash v0.2.8
+	github.com/ipld/go-storethehash v0.2.9-0.20220908183924-c2853ed42ff3
 	github.com/libp2p/go-libp2p-core v0.16.1
 	github.com/multiformats/go-multihash v0.1.0
 	github.com/multiformats/go-varint v0.0.6

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/gammazero/workerpool v1.1.3
 	github.com/ipfs/go-cid v0.2.0
 	github.com/ipfs/go-log/v2 v2.5.1
-	github.com/ipld/go-storethehash v0.2.9-0.20220913012504-e61b43aeeff3
+	github.com/ipld/go-storethehash v0.2.9-0.20220913042011-d185001ca904
 	github.com/libp2p/go-libp2p-core v0.16.1
 	github.com/multiformats/go-multihash v0.1.0
 	github.com/multiformats/go-varint v0.0.6

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/gammazero/workerpool v1.1.3
 	github.com/ipfs/go-cid v0.2.0
 	github.com/ipfs/go-log/v2 v2.5.1
-	github.com/ipld/go-storethehash v0.2.9-0.20220913194629-5b2b5e94324f
+	github.com/ipld/go-storethehash v0.3.0
 	github.com/libp2p/go-libp2p-core v0.16.1
 	github.com/multiformats/go-multihash v0.1.0
 	github.com/multiformats/go-varint v0.0.6

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/gammazero/workerpool v1.1.3
 	github.com/ipfs/go-cid v0.2.0
 	github.com/ipfs/go-log/v2 v2.5.1
-	github.com/ipld/go-storethehash v0.2.9-0.20220908183924-c2853ed42ff3
+	github.com/ipld/go-storethehash v0.2.9-0.20220913012504-e61b43aeeff3
 	github.com/libp2p/go-libp2p-core v0.16.1
 	github.com/multiformats/go-multihash v0.1.0
 	github.com/multiformats/go-varint v0.0.6

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/gammazero/workerpool v1.1.3
 	github.com/ipfs/go-cid v0.2.0
 	github.com/ipfs/go-log/v2 v2.5.1
-	github.com/ipld/go-storethehash v0.2.9-0.20220913065100-86ea4f808869
+	github.com/ipld/go-storethehash v0.2.9-0.20220913194629-5b2b5e94324f
 	github.com/libp2p/go-libp2p-core v0.16.1
 	github.com/multiformats/go-multihash v0.1.0
 	github.com/multiformats/go-varint v0.0.6

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/gammazero/workerpool v1.1.3
 	github.com/ipfs/go-cid v0.2.0
 	github.com/ipfs/go-log/v2 v2.5.1
-	github.com/ipld/go-storethehash v0.3.0
+	github.com/ipld/go-storethehash v0.3.1
 	github.com/libp2p/go-libp2p-core v0.16.1
 	github.com/multiformats/go-multihash v0.1.0
 	github.com/multiformats/go-varint v0.0.6

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/gammazero/workerpool v1.1.3
 	github.com/ipfs/go-cid v0.2.0
 	github.com/ipfs/go-log/v2 v2.5.1
-	github.com/ipld/go-storethehash v0.2.9-0.20220913042011-d185001ca904
+	github.com/ipld/go-storethehash v0.2.9-0.20220913065100-86ea4f808869
 	github.com/libp2p/go-libp2p-core v0.16.1
 	github.com/multiformats/go-multihash v0.1.0
 	github.com/multiformats/go-varint v0.0.6

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/ipfs/go-ipfs-blocksutil v0.0.1 h1:Eh/H4pc1hsvhzsQoMEP3Bke/aW5P5rVM1IW
 github.com/ipfs/go-ipfs-util v0.0.2 h1:59Sswnk1MFaiq+VcaknX7aYEyGyGDAA73ilhEK2POp8=
 github.com/ipfs/go-log/v2 v2.5.1 h1:1XdUzF7048prq4aBjDQQ4SL5RxftpRGdXhNRwKSAlcY=
 github.com/ipfs/go-log/v2 v2.5.1/go.mod h1:prSpmC1Gpllc9UYWxDiZDreBYw7zp4Iqp1kOLU9U5UI=
-github.com/ipld/go-storethehash v0.2.9-0.20220913065100-86ea4f808869 h1:joYy8RYM17IdgolZaElO7nny4sZPaJPrY2v2tvUiSpg=
-github.com/ipld/go-storethehash v0.2.9-0.20220913065100-86ea4f808869/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
+github.com/ipld/go-storethehash v0.2.9-0.20220913194629-5b2b5e94324f h1:awuNmIZivgtnjCJYBNs5hLXivsn77PmXs4FI4vUt5ck=
+github.com/ipld/go-storethehash v0.2.9-0.20220913194629-5b2b5e94324f/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/i18n v0.0.0-20171121225848-987a633949d0/go.mod h1:pMCz62A0xJL6I+umB2YTlFRwWXaDFA0jy+5HzGiJjqI=

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/ipfs/go-ipfs-blocksutil v0.0.1 h1:Eh/H4pc1hsvhzsQoMEP3Bke/aW5P5rVM1IW
 github.com/ipfs/go-ipfs-util v0.0.2 h1:59Sswnk1MFaiq+VcaknX7aYEyGyGDAA73ilhEK2POp8=
 github.com/ipfs/go-log/v2 v2.5.1 h1:1XdUzF7048prq4aBjDQQ4SL5RxftpRGdXhNRwKSAlcY=
 github.com/ipfs/go-log/v2 v2.5.1/go.mod h1:prSpmC1Gpllc9UYWxDiZDreBYw7zp4Iqp1kOLU9U5UI=
-github.com/ipld/go-storethehash v0.2.9-0.20220913012504-e61b43aeeff3 h1:uP/jrPODgQ+PrzREshDfdUgK+2ZoWin0cz19yRywp3g=
-github.com/ipld/go-storethehash v0.2.9-0.20220913012504-e61b43aeeff3/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
+github.com/ipld/go-storethehash v0.2.9-0.20220913042011-d185001ca904 h1:GweqKW44K9MC7fm6kWHLg8up8UsrcEQckk1N+e8uvpg=
+github.com/ipld/go-storethehash v0.2.9-0.20220913042011-d185001ca904/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/i18n v0.0.0-20171121225848-987a633949d0/go.mod h1:pMCz62A0xJL6I+umB2YTlFRwWXaDFA0jy+5HzGiJjqI=

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/ipfs/go-ipfs-blocksutil v0.0.1 h1:Eh/H4pc1hsvhzsQoMEP3Bke/aW5P5rVM1IW
 github.com/ipfs/go-ipfs-util v0.0.2 h1:59Sswnk1MFaiq+VcaknX7aYEyGyGDAA73ilhEK2POp8=
 github.com/ipfs/go-log/v2 v2.5.1 h1:1XdUzF7048prq4aBjDQQ4SL5RxftpRGdXhNRwKSAlcY=
 github.com/ipfs/go-log/v2 v2.5.1/go.mod h1:prSpmC1Gpllc9UYWxDiZDreBYw7zp4Iqp1kOLU9U5UI=
-github.com/ipld/go-storethehash v0.2.8 h1:JtyWG2cCszQ1bdgyH6RBlo12TrSlsd7zdzUVECFnw3Q=
-github.com/ipld/go-storethehash v0.2.8/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
+github.com/ipld/go-storethehash v0.2.9-0.20220908183924-c2853ed42ff3 h1:fho/zakCCHPmwqxsyaoz1fxodbloAo+r6atMxHVHbcc=
+github.com/ipld/go-storethehash v0.2.9-0.20220908183924-c2853ed42ff3/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/i18n v0.0.0-20171121225848-987a633949d0/go.mod h1:pMCz62A0xJL6I+umB2YTlFRwWXaDFA0jy+5HzGiJjqI=

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/ipfs/go-ipfs-blocksutil v0.0.1 h1:Eh/H4pc1hsvhzsQoMEP3Bke/aW5P5rVM1IW
 github.com/ipfs/go-ipfs-util v0.0.2 h1:59Sswnk1MFaiq+VcaknX7aYEyGyGDAA73ilhEK2POp8=
 github.com/ipfs/go-log/v2 v2.5.1 h1:1XdUzF7048prq4aBjDQQ4SL5RxftpRGdXhNRwKSAlcY=
 github.com/ipfs/go-log/v2 v2.5.1/go.mod h1:prSpmC1Gpllc9UYWxDiZDreBYw7zp4Iqp1kOLU9U5UI=
-github.com/ipld/go-storethehash v0.2.9-0.20220913194629-5b2b5e94324f h1:awuNmIZivgtnjCJYBNs5hLXivsn77PmXs4FI4vUt5ck=
-github.com/ipld/go-storethehash v0.2.9-0.20220913194629-5b2b5e94324f/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
+github.com/ipld/go-storethehash v0.3.0 h1:BggAoK0I65GtZ2N65NyYIBTV7YEZsPCkb9VF31ry8DM=
+github.com/ipld/go-storethehash v0.3.0/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/i18n v0.0.0-20171121225848-987a633949d0/go.mod h1:pMCz62A0xJL6I+umB2YTlFRwWXaDFA0jy+5HzGiJjqI=

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/ipfs/go-ipfs-blocksutil v0.0.1 h1:Eh/H4pc1hsvhzsQoMEP3Bke/aW5P5rVM1IW
 github.com/ipfs/go-ipfs-util v0.0.2 h1:59Sswnk1MFaiq+VcaknX7aYEyGyGDAA73ilhEK2POp8=
 github.com/ipfs/go-log/v2 v2.5.1 h1:1XdUzF7048prq4aBjDQQ4SL5RxftpRGdXhNRwKSAlcY=
 github.com/ipfs/go-log/v2 v2.5.1/go.mod h1:prSpmC1Gpllc9UYWxDiZDreBYw7zp4Iqp1kOLU9U5UI=
-github.com/ipld/go-storethehash v0.3.0 h1:BggAoK0I65GtZ2N65NyYIBTV7YEZsPCkb9VF31ry8DM=
-github.com/ipld/go-storethehash v0.3.0/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
+github.com/ipld/go-storethehash v0.3.1 h1:MOMLgG5tWaZsWJuN7UpBpi+/tthdzqdzMVH1LVQ09mo=
+github.com/ipld/go-storethehash v0.3.1/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/i18n v0.0.0-20171121225848-987a633949d0/go.mod h1:pMCz62A0xJL6I+umB2YTlFRwWXaDFA0jy+5HzGiJjqI=

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/ipfs/go-ipfs-blocksutil v0.0.1 h1:Eh/H4pc1hsvhzsQoMEP3Bke/aW5P5rVM1IW
 github.com/ipfs/go-ipfs-util v0.0.2 h1:59Sswnk1MFaiq+VcaknX7aYEyGyGDAA73ilhEK2POp8=
 github.com/ipfs/go-log/v2 v2.5.1 h1:1XdUzF7048prq4aBjDQQ4SL5RxftpRGdXhNRwKSAlcY=
 github.com/ipfs/go-log/v2 v2.5.1/go.mod h1:prSpmC1Gpllc9UYWxDiZDreBYw7zp4Iqp1kOLU9U5UI=
-github.com/ipld/go-storethehash v0.2.9-0.20220913042011-d185001ca904 h1:GweqKW44K9MC7fm6kWHLg8up8UsrcEQckk1N+e8uvpg=
-github.com/ipld/go-storethehash v0.2.9-0.20220913042011-d185001ca904/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
+github.com/ipld/go-storethehash v0.2.9-0.20220913065100-86ea4f808869 h1:joYy8RYM17IdgolZaElO7nny4sZPaJPrY2v2tvUiSpg=
+github.com/ipld/go-storethehash v0.2.9-0.20220913065100-86ea4f808869/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/i18n v0.0.0-20171121225848-987a633949d0/go.mod h1:pMCz62A0xJL6I+umB2YTlFRwWXaDFA0jy+5HzGiJjqI=

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/ipfs/go-ipfs-blocksutil v0.0.1 h1:Eh/H4pc1hsvhzsQoMEP3Bke/aW5P5rVM1IW
 github.com/ipfs/go-ipfs-util v0.0.2 h1:59Sswnk1MFaiq+VcaknX7aYEyGyGDAA73ilhEK2POp8=
 github.com/ipfs/go-log/v2 v2.5.1 h1:1XdUzF7048prq4aBjDQQ4SL5RxftpRGdXhNRwKSAlcY=
 github.com/ipfs/go-log/v2 v2.5.1/go.mod h1:prSpmC1Gpllc9UYWxDiZDreBYw7zp4Iqp1kOLU9U5UI=
-github.com/ipld/go-storethehash v0.2.9-0.20220908183924-c2853ed42ff3 h1:fho/zakCCHPmwqxsyaoz1fxodbloAo+r6atMxHVHbcc=
-github.com/ipld/go-storethehash v0.2.9-0.20220908183924-c2853ed42ff3/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
+github.com/ipld/go-storethehash v0.2.9-0.20220913012504-e61b43aeeff3 h1:uP/jrPODgQ+PrzREshDfdUgK+2ZoWin0cz19yRywp3g=
+github.com/ipld/go-storethehash v0.2.9-0.20220913012504-e61b43aeeff3/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/i18n v0.0.0-20171121225848-987a633949d0/go.mod h1:pMCz62A0xJL6I+umB2YTlFRwWXaDFA0jy+5HzGiJjqI=

--- a/store/storethehash/storethehash.go
+++ b/store/storethehash/storethehash.go
@@ -189,7 +189,7 @@ func (s *SthStorage) RemoveProvider(ctx context.Context, providerID peer.ID) err
 			return err
 		}
 		if done {
-			return nil
+			break
 		}
 
 		// Get the key and value stored in primary to see if it is the same (index

--- a/store/storethehash/storethehash.go
+++ b/store/storethehash/storethehash.go
@@ -13,9 +13,7 @@ import (
 	"github.com/gammazero/keymutex"
 	"github.com/gammazero/workerpool"
 	sth "github.com/ipld/go-storethehash/store"
-	freelist "github.com/ipld/go-storethehash/store/freelist"
-	"github.com/ipld/go-storethehash/store/primary"
-	mhprimary "github.com/ipld/go-storethehash/store/primary/multihash"
+	"github.com/ipld/go-storethehash/store/index"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 	"github.com/multiformats/go-multihash"
 	"golang.org/x/crypto/blake2b"
@@ -43,8 +41,7 @@ type SthStorage struct {
 	// may make this unnecessary.
 	vlk *keymutex.KeyRWMutex
 
-	primary *mhprimary.MultihashPrimary
-	vcodec  indexer.ValueCodec
+	vcodec indexer.ValueCodec
 
 	wp *workerpool.WorkerPool
 	// wpMutex protects replacing wp
@@ -52,9 +49,9 @@ type SthStorage struct {
 }
 
 type sthIterator struct {
-	iter     primary.PrimaryStorageIter
-	storage  *SthStorage
-	uniqKeys map[string]struct{}
+	index     *index.Index
+	indexIter *index.Iterator
+	storage   *SthStorage
 }
 
 // New creates a new indexer.Interface implemented by a storethehash-based
@@ -63,23 +60,10 @@ type sthIterator struct {
 // The given indexer.ValueCodec is used to serialize and deserialize values.
 // If it is set to nil, indexer.JsonValueCodec is used.
 func New(ctx context.Context, dir string, vcodec indexer.ValueCodec, putConcurrency int, options ...sth.Option) (*SthStorage, error) {
-	// Using a single file to store index and data. This may change in the
-	// future, and we may choose to set a max. size to files. Having several
-	// files for storage increases complexity but minimizes the overhead of
-	// compaction (once we have it)
 	indexPath := filepath.Join(dir, "storethehash.index")
 	dataPath := filepath.Join(dir, "storethehash.data")
 
-	freeList, err := freelist.Open(indexPath + ".free")
-	if err != nil {
-		return nil, err
-	}
-	primary, err := mhprimary.Open(dataPath, freeList)
-	if err != nil {
-		return nil, fmt.Errorf("error opening storethehash primary: %w", err)
-	}
-
-	s, err := sth.OpenStore(ctx, indexPath, primary, freeList, false, options...)
+	s, err := sth.OpenStore(ctx, sth.MultihashPrimary, dataPath, indexPath, false, options...)
 	if err != nil {
 		return nil, fmt.Errorf("error opening storethehash index: %w", err)
 	}
@@ -93,13 +77,12 @@ func New(ctx context.Context, dir string, vcodec indexer.ValueCodec, putConcurre
 	}
 
 	return &SthStorage{
-		dir:     dir,
-		store:   s,
-		mlk:     keymutex.New(putConcurrency),
-		vlk:     keymutex.NewRW(0),
-		primary: primary,
-		vcodec:  vcodec,
-		wp:      wp,
+		dir:    dir,
+		store:  s,
+		mlk:    keymutex.New(putConcurrency),
+		vlk:    keymutex.NewRW(0),
+		vcodec: vcodec,
+		wp:     wp,
 	}, nil
 }
 
@@ -192,29 +175,34 @@ func (s *SthStorage) Remove(value indexer.Value, mhs ...multihash.Multihash) err
 
 func (s *SthStorage) RemoveProvider(ctx context.Context, providerID peer.ID) error {
 	s.Flush()
-	iter, err := s.primary.Iter()
-	if err != nil {
-		return err
-	}
 
+	index := s.store.Index()
+	iter := index.NewIterator()
 	var count int
+
 	for {
 		if count%1024 == 0 && ctx.Err() != nil {
 			return ctx.Err()
 		}
 		count++
 
-		// Iterate through all stored items, examining values and skipping
-		// multihashes.
-		key, _, err := iter.Next()
+		rec, done, err := iter.Next()
 		if err != nil {
-			if err == io.EOF {
-				break
-			}
 			return err
 		}
+		if done {
+			return nil
+		}
 
-		// Decode the key and see if it is a value key.
+		// Get the key and value stored in primary to see if it is the same (index
+		// only stores prefixes).
+		key, valueData, err := index.Primary.Get(rec.Block)
+		if err != nil {
+			// Record no longer there, skip
+			continue
+		}
+
+		// Decode the key and see if it is an index key.
 		dm, err := multihash.Decode(key)
 		if err != nil {
 			return err
@@ -224,24 +212,13 @@ func (s *SthStorage) RemoveProvider(ctx context.Context, providerID peer.ID) err
 			continue
 		}
 
-		s.vlk.RLockBytes(key)
-		valueData, found, err := s.store.Get(multihash.Multihash(key))
-		s.vlk.RUnlockBytes(key)
+		value, err := s.vcodec.UnmarshalValue(valueData)
 		if err != nil {
 			return err
 		}
 
-		// If a value was found, skip it if the provider is different than the
-		// one being removed.
-		if found {
-			value, err := s.vcodec.UnmarshalValue(valueData)
-			if err != nil {
-				return err
-			}
-
-			if value.ProviderID != providerID {
-				continue
-			}
+		if value.ProviderID != providerID {
+			continue
 		}
 
 		s.vlk.LockBytes(key)
@@ -318,25 +295,30 @@ func (s *SthStorage) Iter() (indexer.Iterator, error) {
 	if err != nil {
 		return nil, err
 	}
-	iter, err := s.primary.Iter()
-	if err != nil {
-		return nil, err
-	}
+	index := s.store.Index()
 	return &sthIterator{
-		iter:     iter,
-		storage:  s,
-		uniqKeys: map[string]struct{}{},
+		index:     index,
+		indexIter: index.NewIterator(),
+		storage:   s,
 	}, nil
 }
 
 func (it *sthIterator) Next() (multihash.Multihash, []indexer.Value, error) {
 	for {
-		key, _, err := it.iter.Next()
+		rec, done, err := it.indexIter.Next()
 		if err != nil {
-			if err == io.EOF {
-				it.uniqKeys = nil
-			}
 			return nil, nil, err
+		}
+		if done {
+			return nil, nil, io.EOF
+		}
+
+		// Get the key and value stored in primary to see if it is the same (index
+		// only stores prefixes).
+		key, valueKeysData, err := it.index.Primary.Get(rec.Block)
+		if err != nil {
+			// Record no longer there, skip.
+			continue
 		}
 
 		// Decode the key and see if it is an index key.
@@ -346,25 +328,6 @@ func (it *sthIterator) Next() (multihash.Multihash, []indexer.Value, error) {
 		}
 		if !bytes.HasSuffix(dm.Digest, indexKeySuffix) {
 			// Key does not have index prefix, so is not an index key.
-			continue
-		}
-
-		mhb := make([]byte, len(dm.Digest)-len(indexKeySuffix))
-		copy(mhb, dm.Digest)
-		reverseBytes(mhb)
-		origMultihash := multihash.Multihash(mhb)
-		k := string(origMultihash)
-		_, found := it.uniqKeys[k]
-		if found {
-			continue
-		}
-		it.uniqKeys[k] = struct{}{}
-
-		valueKeysData, found, err := it.storage.store.Get(multihash.Multihash(key))
-		if err != nil {
-			return nil, nil, err
-		}
-		if !found {
 			continue
 		}
 
@@ -383,7 +346,11 @@ func (it *sthIterator) Next() (multihash.Multihash, []indexer.Value, error) {
 			continue
 		}
 
-		return origMultihash, values, nil
+		mhb := make([]byte, len(dm.Digest)-len(indexKeySuffix))
+		copy(mhb, dm.Digest)
+		reverseBytes(mhb)
+
+		return multihash.Multihash(mhb), values, nil
 	}
 }
 

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-    "version": "v0.6.2"
+    "version": "v0.6.3"
 }


### PR DESCRIPTION
Use the new storethehash that has GC for the primary.  See https://github.com/ipld/go-storethehash/pull/64.

* Implement iterator and RemoveProvider using new `store.Iterator`
* Includes fix for handling file number wrap with index files.