### PR TITLE
Update to sth with auto migration for index

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/gammazero/workerpool v1.1.3
 	github.com/ipfs/go-cid v0.2.0
 	github.com/ipfs/go-log/v2 v2.5.1
-	github.com/ipld/go-storethehash v0.3.4
+	github.com/ipld/go-storethehash v0.3.5
 	github.com/libp2p/go-libp2p-core v0.16.1
 	github.com/multiformats/go-multihash v0.1.0
 	github.com/multiformats/go-varint v0.0.6

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/ipfs/go-ipfs-blocksutil v0.0.1 h1:Eh/H4pc1hsvhzsQoMEP3Bke/aW5P5rVM1IW
 github.com/ipfs/go-ipfs-util v0.0.2 h1:59Sswnk1MFaiq+VcaknX7aYEyGyGDAA73ilhEK2POp8=
 github.com/ipfs/go-log/v2 v2.5.1 h1:1XdUzF7048prq4aBjDQQ4SL5RxftpRGdXhNRwKSAlcY=
 github.com/ipfs/go-log/v2 v2.5.1/go.mod h1:prSpmC1Gpllc9UYWxDiZDreBYw7zp4Iqp1kOLU9U5UI=
-github.com/ipld/go-storethehash v0.3.4 h1:bLIJEChSmNdItZ22ZV+ENTYEj/4jBx8jxUxsoVGj0ak=
-github.com/ipld/go-storethehash v0.3.4/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
+github.com/ipld/go-storethehash v0.3.5 h1:ieDsEb2C3ona25NbihFnusDo0jJEPgvEYxXMTpHuKXk=
+github.com/ipld/go-storethehash v0.3.5/go.mod h1:WDeK24//CTUrs4kKxB52qNUf65zCCYHGm3r6fPFKV94=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/i18n v0.0.0-20171121225848-987a633949d0/go.mod h1:pMCz62A0xJL6I+umB2YTlFRwWXaDFA0jy+5HzGiJjqI=

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-    "version": "v0.6.6"
+    "version": "v0.6.7"
 }


### PR DESCRIPTION
When a STH is started with a bit size value different that STH was previously run with, STH will automatically migrate the index files.

Specifying 0 for the index size bits uses the value for the existing index, or the default value if the index is now.