### PR TITLE
Handle merge of already serialized value-keys

### DIFF
--- a/store/pebble/key.go
+++ b/store/pebble/key.go
@@ -172,7 +172,10 @@ func (b *blake3Keyer) multihashKey(mh multihash.Multihash) (key, error) {
 func (b *blake3Keyer) keyToMultihash(k key) (multihash.Multihash, error) {
 	switch k.prefix() {
 	case multihashKeyPrefix:
-		return multihash.Multihash(k[1:]), nil
+		keyData := k[1:]
+		mhData := make([]byte, len(keyData))
+		copy(mhData, keyData)
+		return multihash.Multihash(mhData), nil
 	default:
 		return nil, errors.New("key prefix mismatch")
 	}

--- a/store/pebble/key.go
+++ b/store/pebble/key.go
@@ -78,12 +78,16 @@ func (k key) next() key {
 
 // stripMergeDelete removes the mergeDeleteKeyPrefix prefix from this key only if the key
 // has the prefix mergeDeleteKeyPrefix.
-// It returns the resulting key and a bool to signal weather the removal happened.
-func (k key) stripMergeDelete() (key, bool) {
-	if k.prefix() == mergeDeleteKeyPrefix {
-		return k[1:], true
+// It returns the key prefix and the resulting key; mergeDeleteKeyPrefix as the returned prefix
+// signals that the strip has occurred.
+func (k key) stripMergeDelete() (keyPrefix, key) {
+	prefix := k.prefix()
+	switch prefix {
+	case mergeDeleteKeyPrefix:
+		return prefix, k[1:]
+	default:
+		return prefix, k
 	}
-	return k, false
 }
 
 // newBlake3Keyer instantiates a new keyer that uses blake3 hash function, where the

--- a/store/pebble/key_test.go
+++ b/store/pebble/key_test.go
@@ -65,8 +65,8 @@ func Test_blake3Keyer(t *testing.T) {
 		if vk.prefix() != valueKeyPrefix {
 			t.Fatal()
 		}
-		vvk, ok := vk.stripMergeDelete()
-		if ok {
+		p, vvk := vk.stripMergeDelete()
+		if p != valueKeyPrefix {
 			t.Fatal()
 		}
 		if !bytes.Equal(vk, vvk) {
@@ -101,8 +101,8 @@ func Test_blake3Keyer(t *testing.T) {
 		if dvk.prefix() != mergeDeleteKeyPrefix {
 			t.Fatal()
 		}
-		vk2, ok := dvk.stripMergeDelete()
-		if !ok {
+		p, vk2 := dvk.stripMergeDelete()
+		if p != mergeDeleteKeyPrefix {
 			t.Fatal()
 		}
 		if !bytes.Equal(vk, vk2) {

--- a/store/pebble/pebble.go
+++ b/store/pebble/pebble.go
@@ -80,8 +80,11 @@ func (s *store) Get(mh multihash.Multihash) ([]indexer.Value, bool, error) {
 		log.Errorw("can't find multihash", "err", err)
 		return nil, false, err
 	}
-	vks, err := s.vcodec.UnmarshalValueKeys(vkb)
+	vkbcpy := make([]byte, len(vkb))
+	copy(vkbcpy, vkb)
 	_ = vkbClose.Close()
+
+	vks, err := s.vcodec.UnmarshalValueKeys(vkbcpy)
 	if err != nil {
 		return nil, false, err
 	}
@@ -96,8 +99,11 @@ func (s *store) Get(mh multihash.Multihash) ([]indexer.Value, bool, error) {
 			log.Errorw("can't find value", "err", err)
 			return nil, false, err
 		}
-		v, err := s.vcodec.UnmarshalValue(vs)
+		vcpy := make([]byte, len(vs))
+		copy(vcpy, vs)
 		_ = vCloser.Close()
+
+		v, err := s.vcodec.UnmarshalValue(vcpy)
 		if err != nil {
 			return nil, false, err
 		}

--- a/store/pebble/vk_merger_test.go
+++ b/store/pebble/vk_merger_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/filecoin-project/go-indexer-core"
+	"github.com/multiformats/go-multihash"
 )
 
 func TestValueKeysMerger_IsAssociative(t *testing.T) {
@@ -51,7 +52,7 @@ func TestValueKeysMerger_IsAssociative(t *testing.T) {
 }
 
 func TestValueKeysValueMerger_DeleteKeyRemovesValueKeys(t *testing.T) {
-	mh := []byte("lobster")
+	mh := multihash.Multihash("lobster")
 	bk := newBlake3Keyer(10)
 	value1 := indexer.Value{ProviderID: "fish", ContextID: []byte("1")}
 	value2 := indexer.Value{ProviderID: "in", ContextID: []byte("2")}
@@ -75,7 +76,11 @@ func TestValueKeysValueMerger_DeleteKeyRemovesValueKeys(t *testing.T) {
 	}
 
 	subject := newValueKeysMerger()
-	oneMerge, err := subject.Merge(mh, vk1)
+	mk, err := bk.multihashKey(mh)
+	if err != nil {
+		t.Fatal()
+	}
+	oneMerge, err := subject.Merge(mk, vk1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/store/test/tests.go
+++ b/store/test/tests.go
@@ -69,15 +69,18 @@ func E2ETest(t *testing.T, s indexer.Interface) {
 		t.Fatalf("Error putting single multihash again: %s", err)
 	}
 
+	if err := s.Flush(); err != nil {
+		t.Fatal(err)
+	}
 	vals, found, err := s.Get(single)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !found {
-		t.Error("Error finding single multihash")
+		t.Fatal("Error finding single multihash")
 	}
 	if !vals[0].Equal(value1) {
-		t.Error("Got wrong value for single multihash")
+		t.Fatal("Got wrong value for single multihash")
 	}
 
 	// Put a batch of multihashes
@@ -87,6 +90,9 @@ func E2ETest(t *testing.T, s indexer.Interface) {
 		t.Fatalf("Error putting batch of multihashes: %s", err)
 	}
 
+	if err := s.Flush(); err != nil {
+		t.Fatal(err)
+	}
 	vals, found, err = s.Get(mhs[5])
 	if err != nil {
 		t.Fatal(err)
@@ -95,7 +101,7 @@ func E2ETest(t *testing.T, s indexer.Interface) {
 		t.Error("Error finding a multihash from the batch")
 	}
 	if !vals[0].Equal(value1) {
-		t.Error("Got wrong value for single multihash")
+		t.Fatal("Got wrong value for single multihash")
 	}
 
 	// Put on an existing key
@@ -105,6 +111,9 @@ func E2ETest(t *testing.T, s indexer.Interface) {
 		t.Fatalf("Error putting single multihash: %s", err)
 	}
 	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Flush(); err != nil {
 		t.Fatal(err)
 	}
 	vals, found, err = s.Get(single)
@@ -118,7 +127,7 @@ func E2ETest(t *testing.T, s indexer.Interface) {
 		t.Fatal("Update over existing key not correct")
 	}
 	if !vals[1].Equal(value2) {
-		t.Error("Got wrong value for single multihash")
+		t.Fatal("Got wrong value for single multihash")
 	}
 
 	// Iterate values
@@ -187,6 +196,9 @@ func E2ETest(t *testing.T, s indexer.Interface) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if err := s.Flush(); err != nil {
+		t.Fatal(err)
+	}
 
 	vals, found, err = s.Get(v1mh)
 	if err != nil {
@@ -210,6 +222,10 @@ func E2ETest(t *testing.T, s indexer.Interface) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if err := s.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
 	// Getrieve value using different multihash
 	vals, found, err = s.Get(single)
 	if err != nil {
@@ -242,6 +258,7 @@ func E2ETest(t *testing.T, s indexer.Interface) {
 	if err != nil {
 		t.Fatalf("Error putting single multihash: %s", err)
 	}
+
 	vals, found, err = s.Get(single)
 	if err != nil {
 		t.Fatal(err)

--- a/value.go
+++ b/value.go
@@ -153,7 +153,8 @@ func (BinaryValueCodec) UnmarshalValue(b []byte) (Value, error) {
 	if size < 0 || size > buf.Len() {
 		return v, ErrCodecOverflow
 	}
-	v.ContextID = buf.Next(size)
+	v.ContextID = make([]byte, size)
+	buf.Read(v.ContextID)
 
 	// Decode metadata.
 	usize, err = varint.ReadUvarint(buf)
@@ -164,7 +165,8 @@ func (BinaryValueCodec) UnmarshalValue(b []byte) (Value, error) {
 	if size < 0 || size > buf.Len() {
 		return v, ErrCodecOverflow
 	}
-	v.MetadataBytes = buf.Next(size)
+	v.MetadataBytes = make([]byte, size)
+	buf.Read(v.MetadataBytes)
 	if buf.Len() != 0 {
 		return v, fmt.Errorf("too many bytes; %d remain unread", buf.Len())
 	}
@@ -201,7 +203,9 @@ func (BinaryValueCodec) UnmarshalValueKeys(b []byte) ([][]byte, error) {
 		if size < 0 || size > buf.Len() {
 			return vk, ErrCodecOverflow
 		}
-		vk = append(vk, buf.Next(size))
+		vkData := make([]byte, size)
+		buf.Read(vkData)
+		vk = append(vk, vkData)
 	}
 	return vk, nil
 }


### PR DESCRIPTION
Pebble documentation suggests that `Merger` is used by `.Merge` calls on a given key value. However, Pebble uses merger on iteration over values too. Internally, `Get` operations use iterators for example. This means values that are already serialized may be passed to the merger implementation during in-memory traversal.

The previous implementation of value-keys merger did not take this into account and as a result it meant that `Get` failed to find value-keys associated to a multihash since they ended up being double wrapped by the merger value-keys marshaller.

The changes here fixes this issue by checking explicitly that a give value-key has the expected key prefix before proceeding with the remaining merge logic. As a precaution, the merger is also modified to fall back on the default Pebble merger when the key is not of kind multihash-key. Further, the benchmarks are modified to explicitly assert that the inserted values are indeed found for each entry.

The `Get` implementation in Pebble store is also modified to copy the content returned by the backing store to avoid slice invalidation and runtime invalid reference errors captured in #80.

Unrelated to the lookup issue, the changes here also fix typos in benchmarks where workload does not match the benchmark name. Further, the common tests are updated to do a flush as suggested in #93.

Fixes #94, #80.