### PR TITLE
Gracefully recover from nested value-key marshalling

### DIFF
--- a/store/pebble/pebble.go
+++ b/store/pebble/pebble.go
@@ -85,7 +85,10 @@ func (s *store) Get(mh multihash.Multihash) ([]indexer.Value, bool, error) {
 	if err != nil {
 		return nil, false, err
 	}
-	var values []indexer.Value
+
+	// Optimistically set the capacity of values slice to the number of value-keys
+	// in order to reduce the append footprint in the loop below.
+	values := make([]indexer.Value, 0, len(vks))
 	for _, vk := range vks {
 		vs, vCloser, err := s.db.Get(vk)
 		if err == pebble.ErrNotFound {

--- a/store/pebble/vk_merger_test.go
+++ b/store/pebble/vk_merger_test.go
@@ -10,14 +10,33 @@ import (
 	"github.com/multiformats/go-multihash"
 )
 
+var (
+	value1 = indexer.Value{ProviderID: "fish", ContextID: []byte("1")}
+	value2 = indexer.Value{ProviderID: "in", ContextID: []byte("2")}
+	value3 = indexer.Value{ProviderID: "dasea", ContextID: []byte("3")}
+)
+
 func TestValueKeysMerger_IsAssociative(t *testing.T) {
-	key := []byte("fish")
-	a := []byte("A")
-	b := []byte("B")
-	c := []byte("C")
+	bk := newBlake3Keyer(10)
+	k, err := bk.multihashKey(multihash.Multihash("fish"))
+	if err != nil {
+		t.Fatal()
+	}
+	a, err := bk.valueKey(value1, false)
+	if err != nil {
+		t.Fatal()
+	}
+	b, err := bk.valueKey(value2, false)
+	if err != nil {
+		t.Fatal()
+	}
+	c, err := bk.valueKey(value3, false)
+	if err != nil {
+		t.Fatal()
+	}
 
 	subject := newValueKeysMerger()
-	oneMerge, err := subject.Merge(key, a)
+	oneMerge, err := subject.Merge(k, a)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,7 +51,7 @@ func TestValueKeysMerger_IsAssociative(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	anotherMerge, err := subject.Merge(key, c)
+	anotherMerge, err := subject.Merge(k, c)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,9 +73,6 @@ func TestValueKeysMerger_IsAssociative(t *testing.T) {
 func TestValueKeysValueMerger_DeleteKeyRemovesValueKeys(t *testing.T) {
 	mh := multihash.Multihash("lobster")
 	bk := newBlake3Keyer(10)
-	value1 := indexer.Value{ProviderID: "fish", ContextID: []byte("1")}
-	value2 := indexer.Value{ProviderID: "in", ContextID: []byte("2")}
-	value3 := indexer.Value{ProviderID: "dasea", ContextID: []byte("3")}
 
 	vk1, err := bk.valueKey(value1, false)
 	if err != nil {
@@ -108,4 +124,116 @@ func TestValueKeysValueMerger_DeleteKeyRemovesValueKeys(t *testing.T) {
 	if !bytes.Equal(wantVKs, gotVKs) {
 		t.Fatalf("expected %v but got %v", wantVKs, gotVKs)
 	}
+}
+
+func TestValueKeysValueMerger_RepeatedlyMarshalledValueKeys(t *testing.T) {
+
+	bk := newBlake3Keyer(10)
+	mh := multihash.Multihash("lobster")
+	k, err := bk.multihashKey(mh)
+	if err != nil {
+		t.Fatal()
+	}
+
+	vk1, err := bk.valueKey(value1, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vk2, err := bk.valueKey(value2, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vk3, err := bk.valueKey(value3, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Repeatedly marshall the marshalled value
+	want, err := indexer.BinaryValueCodec{}.MarshalValueKeys([][]byte{vk1, vk2, vk3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mvk2, err := indexer.BinaryValueCodec{}.MarshalValueKeys([][]byte{want})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mvk3, err := indexer.BinaryValueCodec{}.MarshalValueKeys([][]byte{mvk2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mvk4, err := indexer.BinaryValueCodec{}.MarshalValueKeys([][]byte{mvk3})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("four nested initial", func(t *testing.T) {
+		subject := newValueKeysMerger()
+		m, err := subject.Merge(k, mvk4)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, _, err := m.Finish(false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(want, got) {
+			t.Fatal()
+		}
+	})
+	t.Run("mix nested newer", func(t *testing.T) {
+		subject := newValueKeysMerger()
+		m, err := subject.Merge(k, vk1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := m.MergeNewer(vk2); err != nil {
+			t.Fatal(err)
+		}
+		if err := m.MergeNewer(mvk3); err != nil {
+			t.Fatal(err)
+		}
+		got, _, err := m.Finish(false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(want, got) {
+			t.Fatal()
+		}
+	})
+
+	reverse, err := indexer.BinaryValueCodec{}.MarshalValueKeys([][]byte{vk3, vk2, vk1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rmvk2, err := indexer.BinaryValueCodec{}.MarshalValueKeys([][]byte{reverse})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("mix nested older", func(t *testing.T) {
+		subject := newValueKeysMerger()
+		m, err := subject.Merge(k, vk3)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := m.MergeOlder(rmvk2); err != nil {
+			t.Fatal(err)
+		}
+		if err := m.MergeOlder(mvk3); err != nil {
+			t.Fatal(err)
+		}
+		if err := m.MergeOlder(vk1); err != nil {
+			t.Fatal(err)
+		}
+		if err := m.MergeOlder(vk2); err != nil {
+			t.Fatal(err)
+		}
+		got, _, err := m.Finish(false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(want, got) {
+			t.Fatal()
+		}
+	})
 }


### PR DESCRIPTION
The previous behaviour of value-key merger in certain scenarios may have been resulted in value-keys being marshalled repeatedly. This was the underlying cause of the issue captured in #94 and corrected in #95.

The work here adds to the corrections by gracefully fixing such records by unmarshalling them recursively until we reach values with the expected key prefix, and de-duplicating them as necessary. The fix is done opportunistically, in that whenever such values are detected during reads and writes they are fixed.

Additional tests are added to simulate nested marshalling of value-keys and assert that the resulting merge is as expected for both merge-older and merge-newer cases.