### PR TITLE
Use zero-copy binary unmarshalling in Pebble store

### DIFF
--- a/store/pebble/codec.go
+++ b/store/pebble/codec.go
@@ -1,0 +1,122 @@
+package pebble
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/filecoin-project/go-indexer-core"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-varint"
+)
+
+var _ indexer.ValueCodec = (*zeroCopyBinaryValueCodec)(nil)
+
+// zeroCopyBinaryValueCodec is a fork of indexer.BinaryValueCodec which does not make a copy of
+// given slices as part of unmarshalling.
+type zeroCopyBinaryValueCodec struct{}
+
+func (zeroCopyBinaryValueCodec) MarshalValue(v indexer.Value) ([]byte, error) {
+	pid := []byte(v.ProviderID)
+	pl := len(pid)
+	upl := uint64(pl)
+	cl := len(v.ContextID)
+	ucl := uint64(cl)
+	ml := len(v.MetadataBytes)
+	uml := uint64(ml)
+	size := varint.UvarintSize(upl) + pl +
+		varint.UvarintSize(ucl) + cl +
+		varint.UvarintSize(uml) + ml
+
+	var buf bytes.Buffer
+	buf.Grow(size)
+	buf.Write(varint.ToUvarint(upl))
+	buf.Write(pid)
+	buf.Write(varint.ToUvarint(ucl))
+	buf.Write(v.ContextID)
+	buf.Write(varint.ToUvarint(uml))
+	buf.Write(v.MetadataBytes)
+	return buf.Bytes(), nil
+}
+
+// UnmarshalValue deserializes a single value without making any copies.
+//
+// If a failure occurs during serialization an error is returned along with
+// the partially deserialized value keys. Only nil error means complete and
+// successful deserialization.
+func (zeroCopyBinaryValueCodec) UnmarshalValue(b []byte) (indexer.Value, error) {
+	var v indexer.Value
+	buf := bytes.NewBuffer(b)
+
+	// Decode provider ID.
+	usize, err := varint.ReadUvarint(buf)
+	if err != nil {
+		return v, err
+	}
+	size := int(usize)
+	if size < 0 || size > buf.Len() {
+		return indexer.Value{}, indexer.ErrCodecOverflow
+	}
+	v.ProviderID = peer.ID(buf.Next(size))
+
+	// Decode context ID.
+	usize, err = varint.ReadUvarint(buf)
+	if err != nil {
+		return v, err
+	}
+	size = int(usize)
+	if size < 0 || size > buf.Len() {
+		return v, indexer.ErrCodecOverflow
+	}
+	v.ContextID = buf.Next(size)
+
+	// Decode metadata.
+	usize, err = varint.ReadUvarint(buf)
+	if err != nil {
+		return v, err
+	}
+	size = int(usize)
+	if size < 0 || size > buf.Len() {
+		return v, indexer.ErrCodecOverflow
+	}
+	v.MetadataBytes = buf.Next(size)
+	if buf.Len() != 0 {
+		return v, fmt.Errorf("too many bytes; %d remain unread", buf.Len())
+	}
+	return v, nil
+}
+
+func (zeroCopyBinaryValueCodec) MarshalValueKeys(vk [][]byte) ([]byte, error) {
+	var buf bytes.Buffer
+	for _, v := range vk {
+		vl := len(v)
+		uvl := uint64(vl)
+		buf.Grow(varint.UvarintSize(uvl) + vl)
+		buf.Write(varint.ToUvarint(uvl))
+		buf.Write(v)
+	}
+	return buf.Bytes(), nil
+}
+
+// UnmarshalValueKeys deserializes value keys without making any copies.
+//
+// If a failure occurs during serialization an error is returned along with
+// the partially deserialized value keys. Only nil error means complete and
+// successful deserialization.
+func (zeroCopyBinaryValueCodec) UnmarshalValueKeys(b []byte) ([][]byte, error) {
+	var vk [][]byte
+	buf := bytes.NewBuffer(b)
+	// Decode each value key.
+	for buf.Len() != 0 {
+		usize, err := varint.ReadUvarint(buf)
+		if err != nil {
+			return vk, err
+		}
+		size := int(usize)
+		if size < 0 || size > buf.Len() {
+			return vk, indexer.ErrCodecOverflow
+		}
+		maybeGrow(vk, 1)
+		vk = append(vk, buf.Next(size))
+	}
+	return vk, nil
+}

--- a/store/pebble/vk_merger.go
+++ b/store/pebble/vk_merger.go
@@ -5,7 +5,6 @@ import (
 	"io"
 
 	"github.com/cockroachdb/pebble"
-	"github.com/filecoin-project/go-indexer-core"
 )
 
 const valueKeysMergerName = "indexer.v1.binary.valueKeysMerger"
@@ -19,7 +18,7 @@ type valueKeysValueMerger struct {
 	merges  [][]byte
 	deletes map[string]struct{}
 	reverse bool
-	codec   indexer.BinaryValueCodec
+	codec   zeroCopyBinaryValueCodec
 }
 
 func newValueKeysMerger() *pebble.Merger {


### PR DESCRIPTION
The root level binary marshalling makes a copy of the given bytes every time. In Pebble, this is not always necessary; specially during heavily used operations like merge.

Make a fork of the binary marshaller in Pebble package such that: 1) unmarshalling logic can be changed to use a zero-copy approach, 2) pebble usage of marshalling is isolated from the remaining repository since merge functionality makes explicit assumption about how binary marshalling works, and 3) the reminder of repo can continue to benefit from the safety of copy-evey-time offered by the root binary unmarshaller.