### PR TITLE
Skip unified 32-bit tests

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -44,25 +44,28 @@ jobs:
           # If package ./A imports ./B, and ./A's tests also cover ./B,
           # this means ./B's coverage will be significantly higher than 0%.
           run: go test -v -shuffle=on -coverprofile=module-coverage.txt -coverpkg=./... ./...
-      - name: Run tests (32 bit)
-        if: ${{ matrix.os != 'macos' }} # can't run 32 bit tests on OSX.
-        uses: protocol/multiple-go-modules@v1.2
-        env:
-          GOARCH: 386
-        with:
-          run: |
-            export "PATH=${{ env.PATH_386 }}:$PATH"
-            go test -v -shuffle=on ./...
-      - name: Run tests with race detector
-        if: ${{ matrix.os == 'ubuntu' }} # speed things up. Windows and OSX VMs are slow
-        uses: protocol/multiple-go-modules@v1.2
-        with:
-          run: go test -v -race ./...
-      - name: Collect coverage files
-        shell: bash
-        run: echo "COVERAGES=$(find . -type f -name 'module-coverage.txt' | tr -s '\n' ',' | sed 's/,$//')" >> $GITHUB_ENV
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # v3.1.0
-        with:
-          files: '${{ env.COVERAGES }}'
-          env_vars: OS=${{ matrix.os }}, GO=${{ matrix.go }}
+# Disable 32-bit tests until option is added to do it gracefully; see:
+#  - https://github.com/protocol/.github/issues/388
+#
+#      - name: Run tests (32 bit)
+#        if: ${{ matrix.os != 'macos' }} # can't run 32 bit tests on OSX.
+#        uses: protocol/multiple-go-modules@v1.2
+#        env:
+#          GOARCH: 386
+#        with:
+#          run: |
+#            export "PATH=${{ env.PATH_386 }}:$PATH"
+#            go test -v -shuffle=on ./...
+#      - name: Run tests with race detector
+#        if: ${{ matrix.os == 'ubuntu' }} # speed things up. Windows and OSX VMs are slow
+#        uses: protocol/multiple-go-modules@v1.2
+#        with:
+#          run: go test -v -race ./...
+#      - name: Collect coverage files
+#        shell: bash
+#        run: echo "COVERAGES=$(find . -type f -name 'module-coverage.txt' | tr -s '\n' ',' | sed 's/,$//')" >> $GITHUB_ENV
+#      - name: Upload coverage to Codecov
+#        uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # v3.1.0
+#        with:
+#          files: '${{ env.COVERAGES }}'
+#          env_vars: OS=${{ matrix.os }}, GO=${{ matrix.go }}

--- a/store/pebble/pebble.go
+++ b/store/pebble/pebble.go
@@ -1,5 +1,3 @@
-//go:build !386
-
 package pebble
 
 import (

--- a/store/pebble/pebble_test.go
+++ b/store/pebble/pebble_test.go
@@ -1,5 +1,3 @@
-//go:build !386
-
 package pebble
 
 import (

--- a/store/pebble/vk_merger.go
+++ b/store/pebble/vk_merger.go
@@ -1,5 +1,3 @@
-//go:build !386
-
 package pebble
 
 import (

--- a/store/pebble/vk_merger_test.go
+++ b/store/pebble/vk_merger_test.go
@@ -1,5 +1,3 @@
-//go:build !386
-
 package pebble
 
 import (

--- a/store/pogreb/pogreb_bench_test.go
+++ b/store/pogreb/pogreb_bench_test.go
@@ -17,30 +17,25 @@ func initBenchStore(b *testing.B) indexer.Interface {
 }
 
 func BenchmarkGet(b *testing.B) {
-	skipIf32bit(b)
 	test.BenchMultihashGet(initBenchStore(b), b)
 }
 func BenchmarkParallelGet(b *testing.B) {
-	skipIf32bit(b)
 	test.BenchParallelMultihashGet(initBenchStore(b), b)
 }
 
 // To run this storage benchmarks run:
 // TEST_STORAGE=true go test -v -timeout=30m
 func TestBenchSingle10MB(t *testing.T) {
-	skipIf32bit(t)
 	test.SkipStorage(t)
 	test.BenchReadAll(initPogreb(t), "10MB", t)
 }
 
 func TestBenchSingle100MB(t *testing.T) {
-	skipIf32bit(t)
 	test.SkipStorage(t)
 	test.BenchReadAll(initPogreb(t), "100MB", t)
 }
 
 func TestBenchSingle1GB(t *testing.T) {
-	skipIf32bit(t)
 	test.SkipStorage(t)
 	test.BenchReadAll(initPogreb(t), "1GB", t)
 }

--- a/store/pogreb/pogreb_test.go
+++ b/store/pogreb/pogreb_test.go
@@ -1,7 +1,6 @@
 package pogreb_test
 
 import (
-	"runtime"
 	"testing"
 
 	"github.com/filecoin-project/go-indexer-core"
@@ -18,8 +17,6 @@ func initPogreb(t *testing.T) indexer.Interface {
 }
 
 func TestE2E(t *testing.T) {
-	skipIf32bit(t)
-
 	s := initPogreb(t)
 	test.E2ETest(t, s)
 	if err := s.Close(); err != nil {
@@ -28,8 +25,6 @@ func TestE2E(t *testing.T) {
 }
 
 func TestParallel(t *testing.T) {
-	skipIf32bit(t)
-
 	s := initPogreb(t)
 	test.ParallelUpdateTest(t, s)
 	if err := s.Close(); err != nil {
@@ -38,8 +33,6 @@ func TestParallel(t *testing.T) {
 }
 
 func TestSize(t *testing.T) {
-	skipIf32bit(t)
-
 	s := initPogreb(t)
 	test.SizeTest(t, s)
 	if err := s.Close(); err != nil {
@@ -48,8 +41,6 @@ func TestSize(t *testing.T) {
 }
 
 func TestRemove(t *testing.T) {
-	skipIf32bit(t)
-
 	s := initPogreb(t)
 	test.RemoveTest(t, s)
 	if err := s.Close(); err != nil {
@@ -58,8 +49,6 @@ func TestRemove(t *testing.T) {
 }
 
 func TestRemoveProviderContext(t *testing.T) {
-	skipIf32bit(t)
-
 	s := initPogreb(t)
 	test.RemoveProviderContextTest(t, s)
 	if err := s.Close(); err != nil {
@@ -68,8 +57,6 @@ func TestRemoveProviderContext(t *testing.T) {
 }
 
 func TestRemoveProvider(t *testing.T) {
-	skipIf32bit(t)
-
 	s := initPogreb(t)
 	test.RemoveProviderTest(t, s)
 	if err := s.Close(); err != nil {
@@ -78,8 +65,6 @@ func TestRemoveProvider(t *testing.T) {
 }
 
 func TestClose(t *testing.T) {
-	skipIf32bit(t)
-
 	s := initPogreb(t)
 	err := s.Close()
 	if err != nil {
@@ -88,11 +73,5 @@ func TestClose(t *testing.T) {
 
 	if err = s.Close(); err != nil {
 		t.Fatal(err)
-	}
-}
-
-func skipIf32bit(t testing.TB) {
-	if runtime.GOARCH == "386" {
-		t.Skip("Pogreb cannot use GOARCH=386")
 	}
 }


### PR DESCRIPTION
Skip the 32-bit tests by commenting out the unified build config until option is added.

See:
 - https://github.com/protocol/.github/issues/388