### PR TITLE
Use only `BinaryValueCode` or `BinaryWithJsonFallbackCodec`

### DIFF
--- a/bench/sth_conc_bench_test.go
+++ b/bench/sth_conc_bench_test.go
@@ -39,7 +39,6 @@ func BenchmarkStore_Sth_PutConcurrency_W1_64(b *testing.B) {
 func sthWithPutConcurrency(b *testing.B, c int) func() (indexer.Interface, error) {
 	return func() (indexer.Interface, error) {
 		return storethehash.New(context.Background(), b.TempDir(),
-			indexer.BinaryValueCodec{},
 			c,
 			sth.GCInterval(0),
 			sth.SyncInterval(3*time.Second),

--- a/bench/store_bench_test.go
+++ b/bench/store_bench_test.go
@@ -187,14 +187,13 @@ func newPebbleSubject(b *testing.B) func() (indexer.Interface, error) {
 
 func newPogrebSubject(b *testing.B) func() (indexer.Interface, error) {
 	return func() (indexer.Interface, error) {
-		return pogreb.New(b.TempDir(), indexer.BinaryValueCodec{})
+		return pogreb.New(b.TempDir())
 	}
 }
 
 func sthSubject(b *testing.B) func() (indexer.Interface, error) {
 	return func() (indexer.Interface, error) {
 		return storethehash.New(context.Background(), b.TempDir(),
-			indexer.BinaryValueCodec{},
 			64,
 			sth.GCInterval(0),
 			sth.SyncInterval(time.Second),

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func initEngine(t *testing.T, withCache, cacheOnPut bool) *Engine {
-	valueStore, err := storethehash.New(context.Background(), t.TempDir(), nil, 4)
+	valueStore, err := storethehash.New(context.Background(), t.TempDir(), 4)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/store/pogreb/pogreb.go
+++ b/store/pogreb/pogreb.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/akrylysov/pogreb"
 	"github.com/filecoin-project/go-indexer-core"
+	"github.com/filecoin-project/go-indexer-core/store/vsinfo"
 	"github.com/gammazero/keymutex"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multihash"
@@ -55,15 +56,39 @@ type pogrebIter struct {
 // The given indexer.ValueCodec is used to serialize and deserialize values.
 // If it is set to nil, indexer.BinaryWithJsonFallbackCodec is used which
 // will gracefully migrate the codec from JSON to Binary format.
-func New(dir string, vcodec indexer.ValueCodec) (indexer.Interface, error) {
+func New(dir string) (indexer.Interface, error) {
 	opts := pogreb.Options{BackgroundSyncInterval: DefaultSyncInterval}
-	if vcodec == nil {
-		vcodec = indexer.BinaryWithJsonFallbackCodec{}
-	}
 	s, err := pogreb.Open(dir, &opts)
 	if err != nil {
 		return nil, err
 	}
+
+	const vstype = "pogreb"
+
+	// Use BinaryWithJsonFallbackCodec codec if the valuestore already exists
+	// and was not created using binary codec.
+	vsInfo, err := vsinfo.Load(dir)
+	if os.IsNotExist(err) {
+		vsInfo.Type = vstype
+		size, err := s.FileSize()
+		if err != nil {
+			return nil, err
+		}
+		if size == 0 {
+			vsInfo.Codec = "binary"
+		} else {
+			vsInfo.Codec = "binaryjson"
+		}
+		vsInfo.Save(dir)
+	} else if vsInfo.Type != vstype {
+		return nil, fmt.Errorf("value store of type %s already exists", vsInfo.Type)
+	}
+
+	vcodec, err := vsInfo.MakeCodec()
+	if err != nil {
+		return nil, err
+	}
+
 	return &pStorage{
 		dir:    dir,
 		store:  s,

--- a/store/pogreb/pogreb_bench_test.go
+++ b/store/pogreb/pogreb_bench_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func initBenchStore(b *testing.B) indexer.Interface {
-	s, err := pogreb.New(b.TempDir(), nil)
+	s, err := pogreb.New(b.TempDir())
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/store/pogreb/pogreb_test.go
+++ b/store/pogreb/pogreb_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func initPogreb(t *testing.T) indexer.Interface {
-	s, err := pogreb.New(t.TempDir(), nil)
+	s, err := pogreb.New(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/store/storethehash/storethehash_bench_test.go
+++ b/store/storethehash/storethehash_bench_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func initBenchStore(b *testing.B, putConcurrency int) indexer.Interface {
-	s, err := storethehash.New(context.Background(), b.TempDir(), nil, putConcurrency)
+	s, err := storethehash.New(context.Background(), b.TempDir(), putConcurrency)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/store/storethehash/storethehash_test.go
+++ b/store/storethehash/storethehash_test.go
@@ -17,7 +17,7 @@ func initSth(t *testing.T, vals ...int) *storethehash.SthStorage {
 	if len(vals) > 0 {
 		putConcurrency = vals[0]
 	}
-	s, err := storethehash.New(context.Background(), t.TempDir(), nil, putConcurrency)
+	s, err := storethehash.New(context.Background(), t.TempDir(), putConcurrency)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,7 +95,7 @@ func TestPeriodicFlush(t *testing.T) {
 
 	syncInterval := 200 * time.Millisecond
 
-	s, err := storethehash.New(context.Background(), tmpDir, nil, 0, sth.SyncInterval(syncInterval))
+	s, err := storethehash.New(context.Background(), tmpDir, 0, sth.SyncInterval(syncInterval))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +121,7 @@ func TestPeriodicFlush(t *testing.T) {
 	time.Sleep(2 * syncInterval)
 
 	// Regenerate new storage
-	s2, err := storethehash.New(context.Background(), tmpDir, nil, 16)
+	s2, err := storethehash.New(context.Background(), tmpDir, 16)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/store/vsinfo/vsinfo.go
+++ b/store/vsinfo/vsinfo.go
@@ -1,0 +1,61 @@
+package vsinfo
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/filecoin-project/go-indexer-core"
+)
+
+const (
+	fileName = "vstore.info"
+	version  = 1
+)
+
+// VStoreInfo contains information about the valuestore.
+type VStoreInfo struct {
+	// Version is the version number of this file.
+	Version int
+	// Type is type of value store.
+	Type string
+	// Codec is the type of codec used for the value store.
+	Codec string
+}
+
+func Load(dir string) (VStoreInfo, error) {
+	data, err := os.ReadFile(filepath.Join(dir, fileName))
+	if err != nil {
+		return VStoreInfo{}, err
+	}
+
+	var vsinfo VStoreInfo
+	err = json.Unmarshal(data, &vsinfo)
+	if err != nil {
+		return VStoreInfo{}, err
+	}
+
+	return vsinfo, nil
+}
+
+func (v VStoreInfo) Save(dir string) error {
+	v.Version = version
+	data, err := json.Marshal(&v)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, fileName), data, 0o666)
+}
+
+func (v VStoreInfo) MakeCodec() (indexer.ValueCodec, error) {
+	switch v.Codec {
+	case "binary":
+		return indexer.BinaryValueCodec{}, nil
+	case "binaryjson":
+		return indexer.BinaryWithJsonFallbackCodec{}, nil
+	case "json":
+		return indexer.JsonValueCodec{}, nil
+	}
+	return nil, fmt.Errorf("unsupported codec: %s", v.Codec)
+}


### PR DESCRIPTION
Use `BinaryWithJsonFallbackCodec` for existing valuestores or `BinaryValueCodec` for new valuestores.