### PR TITLE
Pool Key lists and buffers in Pebble store

### DIFF
--- a/store/pebble/codec.go
+++ b/store/pebble/codec.go
@@ -1,0 +1,100 @@
+package pebble
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/filecoin-project/go-indexer-core"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+const (
+	// marshalledValueKeyLength length is the default key length plus the length of the prefix i.e. 1, plus
+	// the length of its varint length which is also 1.
+	marshalledValueKeyLength = defaultKeyerLength + 1 + 1
+)
+
+// codec offers marshalling compatible with indexer.BinaryValueCodec format but optimised for use
+// in pebble; it does not make copies when possible and returns reusable pooled sectionBuffer,
+// key and keyList to reduce memory footprint where possible.
+type codec struct {
+	p *pool
+}
+
+func (c *codec) marshalValue(v *indexer.Value) ([]byte, io.Closer, error) {
+	buf := c.p.leaseSectionBuff()
+	buf.writeSection([]byte(v.ProviderID))
+	buf.writeSection(v.ContextID)
+	buf.writeSection(v.MetadataBytes)
+	return buf.buf, buf, nil
+}
+
+func (c *codec) unmarshalValue(b []byte) (*indexer.Value, error) {
+	buf := c.p.leaseSectionBuff()
+	defer buf.Close()
+	buf.wrap(b)
+
+	// Decode provider ID.
+	section, err := buf.copyNextSection()
+	if err != nil {
+		return nil, err
+	}
+	var v indexer.Value
+	v.ProviderID = peer.ID(section)
+
+	// Decode context ID.
+	section, err = buf.copyNextSection()
+	if err != nil {
+		return nil, err
+	}
+	v.ContextID = section
+
+	// Decode metadata.
+	section, err = buf.copyNextSection()
+	if err != nil {
+		return nil, err
+	}
+	v.MetadataBytes = section
+	if buf.remaining() != 0 {
+		return nil, fmt.Errorf("too many bytes; %d remain unread", buf.remaining())
+	}
+	return &v, nil
+}
+
+func (c *codec) marshalValueKeys(vk [][]byte) ([]byte, io.Closer, error) {
+	buf := c.p.leaseSectionBuff()
+	buf.maybeGrow(marshalledValueKeyLength * len(vk))
+	for _, v := range vk {
+		buf.writeSection(v)
+	}
+	return buf.buf, buf, nil
+}
+
+func (c *codec) unmarshalValueKeys(b []byte) (*keyList, error) {
+	l := len(b)
+	if l == 0 {
+		return nil, nil
+	}
+	vkl := l / marshalledValueKeyLength
+	if vkl < 1 {
+		return nil, fmt.Errorf("marshalled value-key length %d is shorter than expected minimum %d", l, marshalledValueKeyLength)
+	}
+	vks := c.p.leaseKeyList()
+	vks.maybeGrow(vkl)
+	for i := 0; i < vkl; i++ {
+		vk := c.p.leaseKey()
+		offset := marshalledValueKeyLength * i
+		vk.append(b[offset+1 : offset+marshalledValueKeyLength]...)
+		prefix := vk.prefix()
+		if prefix != valueKeyPrefix {
+			log.Debugf("unexpected key prefix for key: %v", vk)
+			_ = vk.Close()
+			continue
+		}
+		vks.append(vk)
+	}
+	if l%marshalledValueKeyLength != 0 {
+		return vks, indexer.ErrCodecOverflow
+	}
+	return vks, nil
+}

--- a/store/pebble/codec_test.go
+++ b/store/pebble/codec_test.go
@@ -1,0 +1,125 @@
+package pebble
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/filecoin-project/go-indexer-core"
+)
+
+func TestCodec_MarshalledValueKeyLength(t *testing.T) {
+	p := newPool()
+	bk := p.leaseBlake3Keyer()
+	subject := codec{
+		p: p,
+	}
+	valueKey, err := bk.valueKey(value1, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotKyes, _, err := subject.marshalValueKeys([][]byte{valueKey.buf})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(gotKyes) != marshalledValueKeyLength {
+		t.Fatal()
+	}
+}
+
+func TestCodec_ValueKeysMarshalling(t *testing.T) {
+	p := newPool()
+	bk := p.leaseBlake3Keyer()
+	subject := codec{
+		p: p,
+	}
+	vk1, err := bk.valueKey(value1, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vk2, err := bk.valueKey(value2, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vk3, err := bk.valueKey(value3, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vks := [][]byte{vk1.buf, vk2.buf, vk3.buf}
+	gotKeys, _, err := subject.marshalValueKeys(vks)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gotKeyBinCodec, err := indexer.BinaryValueCodec{}.MarshalValueKeys(vks)
+	if err != nil {
+		t.Fatal()
+	}
+	if !bytes.Equal(gotKeys, gotKeyBinCodec) {
+		t.Fatal()
+	}
+
+	gotKeyList, err := subject.unmarshalValueKeys(gotKeys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(gotKeyList.keys) != 3 {
+		t.Fatal()
+	}
+	if !bytes.Equal(gotKeyList.keys[0].buf, vk1.buf) {
+		t.Fatal()
+	}
+	if !bytes.Equal(gotKeyList.keys[1].buf, vk2.buf) {
+		t.Fatal()
+	}
+	if !bytes.Equal(gotKeyList.keys[2].buf, vk3.buf) {
+		t.Fatal()
+	}
+}
+
+func TestCodec_ValueMarshalling(t *testing.T) {
+	binCodec := indexer.BinaryValueCodec{}
+	subject := codec{
+		p: newPool(),
+	}
+	tests := []struct {
+		name  string
+		value *indexer.Value
+	}{
+		{
+			"value1",
+			value1,
+		},
+		{
+			"value2",
+			value2,
+		},
+		{
+			"value3",
+			value3,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			gotMarshalled, _, err := subject.marshalValue(test.value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			gotValue, err := subject.unmarshalValue(gotMarshalled)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(test.value, gotValue) {
+				t.Fatal()
+			}
+			gotMarshalledBinCodec, err := binCodec.MarshalValue(*test.value)
+			if err != nil {
+				t.Fatal()
+			}
+			if !bytes.Equal(gotMarshalled, gotMarshalledBinCodec) {
+				t.Fatal()
+			}
+		})
+	}
+}

--- a/store/pebble/pool.go
+++ b/store/pebble/pool.go
@@ -1,0 +1,61 @@
+package pebble
+
+import (
+	"sync"
+)
+
+const (
+	pooledKeyMaxCap            = 32
+	pooledKeyListMaxCap        = 32
+	pooledSectionBufferMaxCap  = 1 << 10 // 1 KiB
+	pooledSliceCapGrowthFactor = 2
+)
+
+type pool struct {
+	blake3KeyerPool   sync.Pool
+	keyPool           sync.Pool
+	keyListPool       sync.Pool
+	sectionBufferPool sync.Pool
+}
+
+func newPool() *pool {
+	var p pool
+	p.keyPool.New = func() any {
+		return &key{
+			buf: make([]byte, 0, pooledKeyMaxCap),
+			p:   &p,
+		}
+	}
+	p.keyListPool.New = func() any {
+		return &keyList{
+			keys: make([]*key, 0, pooledKeyListMaxCap),
+			p:    &p,
+		}
+	}
+	p.blake3KeyerPool.New = func() any {
+		return newBlake3Keyer(defaultKeyerLength, &p)
+	}
+	p.sectionBufferPool.New = func() any {
+		return &sectionBuffer{
+			buf: make([]byte, 0, pooledSectionBufferMaxCap),
+			p:   &p,
+		}
+	}
+	return &p
+}
+
+func (p *pool) leaseBlake3Keyer() *blake3Keyer {
+	return p.blake3KeyerPool.Get().(*blake3Keyer)
+}
+
+func (p *pool) leaseKey() *key {
+	return p.keyPool.Get().(*key)
+}
+
+func (p *pool) leaseKeyList() *keyList {
+	return p.keyListPool.Get().(*keyList)
+}
+
+func (p *pool) leaseSectionBuff() *sectionBuffer {
+	return p.sectionBufferPool.Get().(*sectionBuffer)
+}

--- a/store/pebble/section_buffer.go
+++ b/store/pebble/section_buffer.go
@@ -1,0 +1,78 @@
+package pebble
+
+import (
+	"io"
+
+	"github.com/filecoin-project/go-indexer-core"
+	"github.com/multiformats/go-varint"
+)
+
+var _ io.Closer = (*sectionBuffer)(nil)
+
+// sectionBuffer offers an efficient way to write and copy byte slices prefixed with their length as
+// varint, referred to as "section". This implementation uses byte slice directly to offer better
+// throughput in comparison with bytes.Buffer.
+type sectionBuffer struct {
+	buf     []byte
+	written int
+	read    int
+	p       *pool
+}
+
+func (bb *sectionBuffer) wrap(d []byte) {
+	bb.buf = append(bb.buf[0:], d...)
+	bb.written = len(d)
+}
+
+func (bb *sectionBuffer) writeSection(b []byte) {
+	l := len(b)
+	ul := uint64(l)
+	size := varint.UvarintSize(ul)
+	bb.maybeGrow(size)
+	bb.buf = bb.buf[:bb.written+size]
+	bb.written += varint.PutUvarint(bb.buf[bb.written:], ul)
+	bb.buf = append(bb.buf, b...)
+	bb.written += l
+}
+
+func (bb *sectionBuffer) copyNextSection() ([]byte, error) {
+	usize, read, err := varint.FromUvarint(bb.buf[bb.read:])
+	bb.read += read
+	if err != nil {
+		return nil, err
+	}
+	size := int(usize)
+	if size < 0 || size > bb.remaining() {
+		return nil, indexer.ErrCodecOverflow
+	}
+
+	section := make([]byte, size)
+	copy(section, bb.buf[bb.read:size+bb.read])
+	bb.read += size
+	return section, nil
+}
+
+func (bb *sectionBuffer) maybeGrow(n int) {
+	l := len(bb.buf)
+	switch {
+	case n <= cap(bb.buf)-l:
+	case l == 0:
+		bb.buf = make([]byte, 0, n*pooledSliceCapGrowthFactor)
+	default:
+		bb.buf = append(make([]byte, 0, (l+n)*pooledSliceCapGrowthFactor), bb.buf...)
+	}
+}
+
+func (bb *sectionBuffer) Close() error {
+	if cap(bb.buf) <= pooledSectionBufferMaxCap {
+		bb.buf = bb.buf[:0]
+		bb.written = 0
+		bb.read = 0
+		bb.p.sectionBufferPool.Put(bb)
+	}
+	return nil
+}
+
+func (bb *sectionBuffer) remaining() int {
+	return len(bb.buf[bb.read:bb.written])
+}

--- a/store/pebble/section_buffer_test.go
+++ b/store/pebble/section_buffer_test.go
@@ -1,0 +1,54 @@
+package pebble
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestSectionBuffer_WriteAndCopySection(t *testing.T) {
+	p := newPool()
+	subject := p.leaseSectionBuff()
+
+	wantS1 := []byte("fish")
+	subject.writeSection(wantS1)
+	wantS2 := []byte("lobster")
+	subject.writeSection(wantS2)
+	wantS3 := []byte("barreleye")
+	subject.writeSection(wantS3)
+
+	s1, err := subject.copyNextSection()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(wantS1, s1) {
+		t.Fatal()
+	}
+	s2, err := subject.copyNextSection()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(wantS2, s2) {
+		t.Fatal()
+	}
+	s3, err := subject.copyNextSection()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(wantS3, s3) {
+		t.Fatal()
+	}
+
+	if err := subject.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(wantS1, s1) {
+		t.Fatal()
+	}
+	if !bytes.Equal(wantS2, s2) {
+		t.Fatal()
+	}
+	if !bytes.Equal(wantS3, s3) {
+		t.Fatal()
+	}
+}


### PR DESCRIPTION
Pool buffers, keys, keyer and key list in order to reduce CPU and memory footprint in Pebble store implementation.

Increase merger efficiency by avoiding recursion when flattening marshalled value keys. Instead, use mod to skip to where the serialized value keys should begin. This works because varint length is always added to the begining of value keys and their length is fixed in pebble store to 20 + 1.

During merge any value keys with unexpected key prefix are skipped. This automatically removes such keys from the store as they will be excluded from the merge.