### PR TITLE
Introduce `Stats` API to expose valustore statistics

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -226,3 +226,7 @@ func (e *Engine) updateCacheStats() {
 		stats.Record(context.Background(), ms...)
 	}
 }
+
+func (e *Engine) Stats() (*indexer.Stats, error) {
+	return e.valueStore.Stats()
+}

--- a/interface.go
+++ b/interface.go
@@ -2,16 +2,20 @@ package indexer
 
 import (
 	"context"
+	"errors"
 
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multihash"
 )
 
+// ErrStatsNotSupported signals that an indexer.Interface does not support Stats calculation.
+var ErrStatsNotSupported = errors.New("stats is not supported by store")
+
 type Interface interface {
 	// Get retrieves a slice of Value for a multihash.
 	Get(multihash.Multihash) ([]Value, bool, error)
 
-	// Put stores a Value and adds a mapping from each of the given multihashs
+	// Put stores a Value and adds a mapping from each of the given multihashes
 	// to that Value. If the Value has the same ProviderID and ContextID as a
 	// previously stored Value, then update the metadata in the stored Value
 	// with the metadata from the provided Value. Call Put without any
@@ -45,6 +49,10 @@ type Interface interface {
 
 	// Iter creates a new value store iterator.
 	Iter() (Iterator, error)
+
+	// Stats returns statistical information about the indexed values.
+	// If unsupported by the backing store, ErrStatsNotSupported is returned.
+	Stats() (*Stats, error)
 }
 
 // Iterator iterates multihashes and values in the value store. Any write
@@ -58,4 +66,10 @@ type Iterator interface {
 	// The iterator will no longer be usable after a call to this function and is
 	// discarded.
 	Close() error
+}
+
+// Stats provides statistics about the indexed values.
+type Stats struct {
+	// MultihashCount is the number of unique multihashes indexed.
+	MultihashCount uint64
 }

--- a/store/pogreb/pogreb.go
+++ b/store/pogreb/pogreb.go
@@ -206,6 +206,10 @@ func (s *pStorage) Close() error {
 	return err
 }
 
+func (s *pStorage) Stats() (*indexer.Stats, error) {
+	return nil, indexer.ErrStatsNotSupported
+}
+
 func (s *pStorage) Iter() (indexer.Iterator, error) {
 	err := s.store.Sync()
 	if err != nil {

--- a/store/storethehash/storethehash.go
+++ b/store/storethehash/storethehash.go
@@ -277,6 +277,10 @@ func (s *SthStorage) Close() error {
 	return s.store.Close()
 }
 
+func (s *SthStorage) Stats() (*indexer.Stats, error) {
+	return nil, indexer.ErrStatsNotSupported
+}
+
 func (s *SthStorage) SetFileCacheSize(size int) {
 	s.store.SetFileCacheSize(size)
 }


### PR DESCRIPTION
Expose an API that, when supported by the backing store, it returns the number of unique multihashes stored.

Implement stats calculation for pebble as an estimate of the number of entries in SST files when the key range falls with the multihash key start/end.

Relates to: https://github.com/filecoin-project/storetheindex/issues/982